### PR TITLE
bug: added support for notifications message type (returning nothing per spec)

### DIFF
--- a/src/include/server/mcp_server.hpp
+++ b/src/include/server/mcp_server.hpp
@@ -135,6 +135,7 @@ private:
     void ServerLoop();
     void HandleConnection(unique_ptr<MCPTransport> transport);
     MCPMessage HandleRequest(const MCPMessage &request);
+    void HandleNotification(const MCPMessage &request);
     
     // Protocol handlers
     MCPMessage HandleInitialize(const MCPMessage &request);


### PR DESCRIPTION
Per my issue in for codex, the MCP protocol requires servers to return nothing when being a sent a notification message. 

https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle