### PR TITLE
Add PRAGMA functions, config mode, and COMMAND option in ATTACH

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ LOAD 'duckdb_mcp';
 CREATE TABLE products (id INT, name VARCHAR, price DECIMAL(10,2));
 INSERT INTO products VALUES (1, 'Widget', 9.99), (2, 'Gadget', 24.99);
 
-SELECT mcp_server_start('stdio', 'localhost', 0, '{}');
+PRAGMA mcp_server_start('stdio');
 ```
 
 Add to Claude Desktop configuration:
@@ -51,7 +51,7 @@ Run DuckDB as an HTTP server that any HTTP client can connect to:
 LOAD 'duckdb_mcp';
 
 -- Start HTTP server with authentication
-SELECT mcp_server_start('http', 'localhost', 8080, '{"auth_token": "secret"}');
+PRAGMA mcp_server_start('http', 'localhost', 8080, '{"auth_token": "secret"}');
 ```
 
 Then connect via HTTP:
@@ -96,7 +96,7 @@ SELECT mcp_call_tool('server', 'analyze', '{"dataset": "sales"}');
 ## Publishing Custom Tools
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'search_products',
     'Search products by name',
     'SELECT * FROM products WHERE name ILIKE ''%'' || $query || ''%''',
@@ -105,6 +105,17 @@ SELECT mcp_publish_tool(
     'markdown'
 );
 ```
+
+## PRAGMA vs SELECT
+
+All server management and publishing functions are available in two forms:
+
+| Form | When to use | Example |
+|------|-------------|---------|
+| `PRAGMA` | Init scripts, fire-and-forget | `PRAGMA mcp_server_start('stdio');` |
+| `SELECT` | When you need the return value | `SELECT mcp_server_status();` |
+
+`PRAGMA` versions produce no output, making init scripts clean. `SELECT` versions return status messages or structs.
 
 ## Documentation
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,38 @@ All notable changes to the DuckDB MCP Extension.
 
 ---
 
+## v1.5.2
+
+### New Features
+
+**PRAGMA Functions**
+
+- All server management and publishing functions now have `PRAGMA` versions that produce no output
+- `PRAGMA mcp_server_start('transport')`, `PRAGMA mcp_server_stop`, etc.
+- `PRAGMA mcp_publish_tool(...)`, `PRAGMA mcp_publish_table(...)`, `PRAGMA mcp_publish_query(...)`, `PRAGMA mcp_publish_resource(...)`, `PRAGMA mcp_register_prompt_template(...)`
+- PRAGMA versions support the same queuing behavior as SELECT versions (publish before server starts)
+- Recommended for init scripts where return values are not needed
+
+**Config Mode**
+
+- `PRAGMA mcp_config_begin` / `PRAGMA mcp_config_end` to suppress output from SELECT versions of MCP functions
+- Useful for backward compatibility with existing `SELECT`-based init scripts
+- Side effects still execute; only the result output is suppressed
+
+**COMMAND Option in ATTACH**
+
+- New `COMMAND` option for the `ATTACH` statement: `ATTACH '' AS srv (TYPE mcp, COMMAND 'python3', ARGS '["server.py"]')`
+- Provides an explicit alternative to overloading the ATTACH path slot
+- When both `COMMAND` and a path are provided, `COMMAND` takes priority
+
+### Internal Changes
+
+- Refactored server functions to extract `*Core()` implementations (taking `ClientContext &`) from scalar wrappers
+- PRAGMA wrappers and scalar wrappers both delegate to the same core functions
+- Config mode flag stored in `MCPConfiguration` struct, accessed via `MCPConfigManager::IsConfigMode()`
+
+---
+
 ## v1.4.0
 
 ### New Features

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ INSERT INTO products VALUES
     (3, 'Gizmo', 14.99, 'Electronics');
 
 -- Start the MCP server (stdio transport for CLI integration)
-SELECT mcp_server_start('stdio', 'localhost', 0, '{}');
+PRAGMA mcp_server_start('stdio');
 ```
 
 ### 2. Run the Server

--- a/docs/guides/custom-tools.md
+++ b/docs/guides/custom-tools.md
@@ -15,7 +15,7 @@ Custom tools let you expose domain-specific SQL queries as named operations that
 ### Simple Example
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'get_user',                                    -- Tool name
     'Retrieve user information by ID',             -- Description
     'SELECT * FROM users WHERE id = $id',          -- SQL template
@@ -38,7 +38,7 @@ The client calls it with:
 Parameters use `$name` syntax in the SQL template:
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'search_products',
     'Search products by name and category',
     'SELECT * FROM products
@@ -102,7 +102,7 @@ The parameter schema follows JSON Schema format:
 The fifth argument specifies which parameters are required:
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'list_orders',
     'List orders with optional filters',
     'SELECT * FROM orders
@@ -130,7 +130,7 @@ For required parameters:
 Specify the output format with the optional 6th parameter:
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'sales_report',
     'Generate sales report',
     'SELECT region, SUM(amount) as total FROM sales GROUP BY region',
@@ -153,7 +153,7 @@ SELECT mcp_publish_tool(
 ### Aggregation Tools
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'revenue_summary',
     'Get revenue summary by time period',
     'SELECT
@@ -183,7 +183,7 @@ SELECT mcp_publish_tool(
 ### Search with LIKE Patterns
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'search_customers',
     'Search customers by name or email',
     'SELECT id, name, email, created_at
@@ -203,7 +203,7 @@ SELECT mcp_publish_tool(
 ### Join Queries
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'order_details',
     'Get full order details including items and customer',
     'SELECT
@@ -228,7 +228,7 @@ SELECT mcp_publish_tool(
 ### Computed Analytics
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'customer_lifetime_value',
     'Calculate customer lifetime value metrics',
     'SELECT
@@ -263,7 +263,7 @@ CREATE OR REPLACE MACRO product_search(search_term, category, max_price) AS TABL
     ORDER BY price;
 
 -- Publish as a tool
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'product_search',
     'Search products with filters',
     'SELECT * FROM product_search($query, $category, $max_price)',
@@ -284,7 +284,7 @@ SELECT mcp_publish_tool(
 Parameters are substituted safely (not concatenated), but validate at the SQL level:
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'get_item',
     'Get item by ID',
     'SELECT * FROM items WHERE id = CAST($id AS INTEGER) LIMIT 1',
@@ -316,10 +316,10 @@ Use the memory transport to test tools:
 
 ```sql
 -- Start test server
-SELECT mcp_server_start('memory', 'localhost', 0, '{}');
+PRAGMA mcp_server_start('memory');
 
 -- Publish tool
-SELECT mcp_publish_tool('test_tool', 'Test', 'SELECT $x + $y as sum',
+PRAGMA mcp_publish_tool('test_tool', 'Test', 'SELECT $x + $y as sum',
     '{"x": {"type": "integer"}, "y": {"type": "integer"}}', '["x", "y"]');
 
 -- Initialize

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -9,10 +9,21 @@ These functions are used when DuckDB acts as an MCP client, connecting to extern
 Attach an MCP server as a named connection:
 
 ```sql
+-- Command as the ATTACH path (original syntax)
 ATTACH '<command>' AS <server_name> (
     TYPE mcp,
-    TRANSPORT '<transport>',
-    ARGS '<json_array>',
+    [TRANSPORT '<transport>'],
+    [ARGS '<json_array>'],
+    [CWD '<working_directory>'],
+    [ENV '<json_object>']
+);
+
+-- Command as an explicit option (new syntax)
+ATTACH '' AS <server_name> (
+    TYPE mcp,
+    COMMAND '<command>',
+    [TRANSPORT '<transport>'],
+    [ARGS '<json_array>'],
     [CWD '<working_directory>'],
     [ENV '<json_object>']
 );
@@ -22,19 +33,30 @@ ATTACH '<command>' AS <server_name> (
 
 | Parameter | Description |
 |-----------|-------------|
-| `command` | The executable to run (e.g., `python3`, `node`) |
+| `command` (path) | The executable to run, specified as the ATTACH path |
+| `COMMAND` (option) | The executable to run, specified as an explicit option. Takes priority over the path. |
 | `server_name` | Alias to reference this server in queries |
 | `TRANSPORT` | Transport protocol: `stdio` (default), `tcp`, `websocket` |
 | `ARGS` | JSON array of command-line arguments |
 | `CWD` | Working directory for the server process |
 | `ENV` | JSON object of environment variables |
 
+!!! tip "COMMAND option vs path"
+    The `COMMAND` option provides the same functionality as the ATTACH path but is more explicit. When both are provided, `COMMAND` takes priority. Use `COMMAND` when you want to keep the path slot empty or use it for a display name.
+
 **Examples:**
 
 ```sql
--- Simple stdio server
+-- Simple stdio server (command as path)
 ATTACH 'python3' AS my_server (
     TYPE mcp,
+    ARGS '["server.py"]'
+);
+
+-- Using explicit COMMAND option
+ATTACH '' AS my_server (
+    TYPE mcp,
+    COMMAND 'python3',
     ARGS '["server.py"]'
 );
 

--- a/src/duckdb_mcp_config.cpp
+++ b/src/duckdb_mcp_config.cpp
@@ -27,6 +27,24 @@ void MCPConfigManager::SetConfig(DatabaseInstance &db, unique_ptr<MCPConfigurati
 	configs[&db] = std::move(config);
 }
 
+bool MCPConfigManager::IsConfigMode(DatabaseInstance &db) {
+	lock_guard<mutex> lock(config_mutex);
+	auto it = configs.find(&db);
+	if (it == configs.end()) {
+		return false;
+	}
+	return it->second->config_mode;
+}
+
+void MCPConfigManager::SetConfigMode(DatabaseInstance &db, bool mode) {
+	lock_guard<mutex> lock(config_mutex);
+	auto it = configs.find(&db);
+	if (it == configs.end()) {
+		configs[&db] = make_uniq<MCPConfiguration>();
+	}
+	configs[&db]->config_mode = mode;
+}
+
 // Helper function to parse JSON arrays
 static vector<string> ParseJSONArray(Connection &conn, const string &json_array) {
 	vector<string> result;

--- a/src/include/duckdb_mcp_config.hpp
+++ b/src/include/duckdb_mcp_config.hpp
@@ -24,6 +24,7 @@ struct MCPConfiguration {
 	bool allow_write_queries = true;
 	string transport = "stdio";
 	unordered_map<string, Value> custom_settings;
+	bool config_mode = false;
 };
 
 // Global configuration management
@@ -35,6 +36,8 @@ private:
 public:
 	static MCPConfiguration &GetConfig(DatabaseInstance &db);
 	static void SetConfig(DatabaseInstance &db, unique_ptr<MCPConfiguration> config);
+	static bool IsConfigMode(DatabaseInstance &db);
+	static void SetConfigMode(DatabaseInstance &db, bool mode);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb_mcp_extension.hpp
+++ b/src/include/duckdb_mcp_extension.hpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 // Extension version constant - update this when releasing new versions
-constexpr const char *DUCKDB_MCP_VERSION = "1.4.0";
+constexpr const char *DUCKDB_MCP_VERSION = "1.5.2";
 
 class DuckdbMcpExtension : public Extension {
 public:

--- a/test/sql/mcp_attach_command_option.test
+++ b/test/sql/mcp_attach_command_option.test
@@ -1,0 +1,57 @@
+# name: test/sql/mcp_attach_command_option.test
+# description: Test COMMAND option in ATTACH for MCP client connections
+# group: [sql]
+
+# This test verifies the COMMAND option works in structured ATTACH mode.
+# Since we can't actually connect to MCP servers in unit tests (no external
+# processes), we test that the parsing works correctly by checking that
+# invalid commands produce appropriate security errors.
+
+require duckdb_mcp
+
+statement ok
+LOAD duckdb_mcp;
+
+# =============================================================================
+# SECTION 1: COMMAND option triggers structured mode
+# =============================================================================
+
+# Using COMMAND option with transport should trigger structured mode.
+# This will fail at security validation (not in allowed commands),
+# which proves the COMMAND option was parsed successfully.
+statement error
+ATTACH '' AS cmd_test (TYPE mcp, COMMAND 'nonexistent_binary', TRANSPORT 'stdio');
+----
+not allowed
+
+# =============================================================================
+# SECTION 2: COMMAND option without path
+# =============================================================================
+
+# COMMAND alone (no TRANSPORT, ARGS, etc.) should still trigger structured mode
+statement error
+ATTACH '' AS cmd_only_test (TYPE mcp, COMMAND 'some_command');
+----
+not allowed
+
+# =============================================================================
+# SECTION 3: COMMAND takes priority over path
+# =============================================================================
+
+# When both path and COMMAND are provided, COMMAND wins.
+# The error message should reference the COMMAND value ('command_value'), not the path.
+statement error
+ATTACH 'path_value' AS priority_test (TYPE mcp, COMMAND 'command_value', TRANSPORT 'stdio');
+----
+command_value
+
+# =============================================================================
+# SECTION 4: Empty COMMAND falls back to path
+# =============================================================================
+
+# When COMMAND is empty but path is provided, path is used as fallback.
+# The error should reference the path value.
+statement error
+ATTACH 'fallback_path' AS fallback_test (TYPE mcp, COMMAND '', TRANSPORT 'stdio');
+----
+fallback_path

--- a/test/sql/mcp_pragma_functions.test
+++ b/test/sql/mcp_pragma_functions.test
@@ -1,0 +1,272 @@
+# name: test/sql/mcp_pragma_functions.test
+# description: Test PRAGMA versions of MCP server functions and config mode
+# group: [sql]
+
+require duckdb_mcp
+
+statement ok
+LOAD duckdb_mcp;
+
+# =============================================================================
+# SETUP: Force clean state
+# =============================================================================
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# SECTION 1: PRAGMA mcp_server_start / mcp_server_stop lifecycle
+# =============================================================================
+
+# Start server via PRAGMA (no output, just succeeds)
+statement ok
+PRAGMA mcp_server_start('memory');
+
+# Verify server is actually running via SELECT (status query is not a PRAGMA)
+query I
+SELECT (mcp_server_status()).running;
+----
+true
+
+# Stop server via PRAGMA
+statement ok
+PRAGMA mcp_server_stop;
+
+# Verify server is stopped
+query I
+SELECT (mcp_server_status()).running;
+----
+false
+
+# =============================================================================
+# SECTION 2: PRAGMA mcp_server_start with config JSON
+# =============================================================================
+
+statement ok
+PRAGMA mcp_server_start('memory', '{"background": true}');
+
+query I
+SELECT (mcp_server_status()).running;
+----
+true
+
+# Force stop via PRAGMA
+statement ok
+PRAGMA mcp_server_stop(true);
+
+query I
+SELECT (mcp_server_status()).running;
+----
+false
+
+# =============================================================================
+# SECTION 3: PRAGMA publish functions (before server starts = queued)
+# =============================================================================
+
+# Create test table
+statement ok
+CREATE TABLE IF NOT EXISTS pragma_products AS SELECT 1 as id, 'Widget' as name, 10.99 as price;
+
+# Publish tool via PRAGMA (queued silently)
+statement ok
+PRAGMA mcp_publish_tool('pragma_tool', 'Test tool via PRAGMA', 'SELECT * FROM pragma_products WHERE id = $id', '{"id":{"type":"integer"}}', '["id"]');
+
+# Publish table via PRAGMA (simple form)
+statement ok
+PRAGMA mcp_publish_table('pragma_products');
+
+# Publish table via PRAGMA (full form)
+statement ok
+PRAGMA mcp_publish_table('pragma_products', 'data://pragma-products-custom', 'json');
+
+# Publish query via PRAGMA (simple form)
+statement ok
+PRAGMA mcp_publish_query('SELECT COUNT(*) as cnt FROM pragma_products', 'data://pragma-count');
+
+# Publish resource via PRAGMA
+statement ok
+PRAGMA mcp_publish_resource('info://pragma-test', 'Hello from PRAGMA', 'text/plain', 'Test resource');
+
+# Register prompt template via PRAGMA
+statement ok
+PRAGMA mcp_register_prompt_template('pragma_prompt', 'A test prompt', 'Hello {name}, welcome to {place}!');
+
+# =============================================================================
+# SECTION 4: Start server and verify queued items are registered
+# =============================================================================
+
+statement ok
+PRAGMA mcp_server_start('memory');
+
+# Verify the tool was registered
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}') LIKE '%pragma_tool%';
+----
+true
+
+# Verify the table resource was registered (default URI)
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}') LIKE '%data://tables/pragma_products%';
+----
+true
+
+# Verify the custom-URI table resource
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":3,"method":"resources/list","params":{}}') LIKE '%data://pragma-products-custom%';
+----
+true
+
+# Verify the query resource
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":4,"method":"resources/list","params":{}}') LIKE '%data://pragma-count%';
+----
+true
+
+# Verify the static resource
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":5,"method":"resources/list","params":{}}') LIKE '%info://pragma-test%';
+----
+true
+
+# Verify the tool actually works
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"pragma_tool","arguments":{"id":1}}}') LIKE '%Widget%';
+----
+true
+
+# Read the static resource content
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":7,"method":"resources/read","params":{"uri":"info://pragma-test"}}') LIKE '%Hello from PRAGMA%';
+----
+true
+
+# =============================================================================
+# SECTION 5: PRAGMA publish while server is running (immediate registration)
+# =============================================================================
+
+# Publish tool via PRAGMA while server is running
+statement ok
+PRAGMA mcp_publish_tool('pragma_live_tool', 'Live tool', 'SELECT 42 as answer', '{}', '[]');
+
+# Verify it's immediately available
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":10,"method":"tools/list","params":{}}') LIKE '%pragma_live_tool%';
+----
+true
+
+# Publish tool with format via PRAGMA
+statement ok
+PRAGMA mcp_publish_tool('pragma_md_tool', 'Markdown tool', 'SELECT 1 as x', '{}', '[]', 'markdown');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":11,"method":"tools/list","params":{}}') LIKE '%pragma_md_tool%';
+----
+true
+
+# Publish query with full args via PRAGMA
+statement ok
+PRAGMA mcp_publish_query('SELECT 99 as val', 'data://pragma-99', 'json', 0);
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":12,"method":"resources/list","params":{}}') LIKE '%data://pragma-99%';
+----
+true
+
+# =============================================================================
+# SECTION 6: Config mode — suppress SELECT output
+# =============================================================================
+
+# First, stop and restart clean for config mode test
+statement ok
+PRAGMA mcp_server_stop(true);
+
+# Enter config mode
+statement ok
+PRAGMA mcp_config_begin;
+
+# In config mode, SELECT versions produce empty/minimal output
+# Server start — returns minimal status struct
+query I
+SELECT (mcp_server_start('memory')).message;
+----
+(empty)
+
+# Publish tool — returns empty string
+query I
+SELECT mcp_publish_tool('config_tool', 'Tool in config mode', 'SELECT 1', '{}', '[]');
+----
+(empty)
+
+# Publish table — returns empty string
+query I
+SELECT mcp_publish_table('pragma_products', 'data://config-products', 'json');
+----
+(empty)
+
+# Publish resource — returns empty string
+query I
+SELECT mcp_publish_resource('info://config-res', 'Config content', 'text/plain', 'desc');
+----
+(empty)
+
+# Register template — returns empty string
+query I
+SELECT mcp_register_prompt_template('config_prompt', 'desc', 'template {x}');
+----
+(empty)
+
+# Exit config mode
+statement ok
+PRAGMA mcp_config_end;
+
+# After config_end, output is back to normal
+query I
+SELECT mcp_publish_resource('info://after-config', 'After config', 'text/plain', 'desc') LIKE 'SUCCESS%';
+----
+true
+
+# Verify the config-mode operations actually took effect
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":20,"method":"tools/list","params":{}}') LIKE '%config_tool%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":21,"method":"resources/list","params":{}}') LIKE '%data://config-products%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":22,"method":"resources/list","params":{}}') LIKE '%info://config-res%';
+----
+true
+
+# =============================================================================
+# SECTION 7: Config mode idempotency
+# =============================================================================
+
+# Calling config_begin twice is harmless
+statement ok
+PRAGMA mcp_config_begin;
+
+statement ok
+PRAGMA mcp_config_begin;
+
+# Calling config_end restores normal output
+statement ok
+PRAGMA mcp_config_end;
+
+query I
+SELECT mcp_publish_resource('info://idempotent', 'test', 'text/plain', '') LIKE 'SUCCESS%';
+----
+true
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+DROP TABLE IF EXISTS pragma_products;


### PR DESCRIPTION
- PRAGMA versions of all MCP server/publish functions (no output, ideal for init scripts)
- Config mode (PRAGMA mcp_config_begin/end) to suppress SELECT output
- COMMAND option in ATTACH for explicit command specification
- Extracted *Core() functions shared by both PRAGMA and scalar wrappers
- Updated all docs to recommend PRAGMA syntax
- Bumped version to 1.5.2