### PR TITLE
Fix missing JSON escaping in tool handler outputs

### DIFF
--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -523,13 +523,13 @@ string ExportToolHandler::FormatData(QueryResult &result, const string &format) 
 				for (idx_t col = 0; col < chunk->ColumnCount(); col++) {
 					if (col > 0)
 						json += ",";
-					json += "\"" + result.names[col] + "\":";
+					json += "\"" + EscapeJsonString(result.names[col]) + "\":";
 
 					auto value = chunk->GetValue(col, i);
 					if (value.IsNull()) {
 						json += "null";
 					} else {
-						json += "\"" + value.ToString() + "\"";
+						json += "\"" + EscapeJsonString(value.ToString()) + "\"";
 					}
 				}
 				json += "}";
@@ -845,10 +845,10 @@ CallToolResult ListTablesToolHandler::Execute(const Value &arguments) {
 				auto obj_type = chunk->GetValue(5, i);
 
 				json += "{";
-				json += "\"database\":\"" + db_name.ToString() + "\",";
-				json += "\"schema\":\"" + schema_name.ToString() + "\",";
-				json += "\"name\":\"" + table_name.ToString() + "\",";
-				json += "\"type\":\"" + obj_type.ToString() + "\",";
+				json += "\"database\":\"" + EscapeJsonString(db_name.ToString()) + "\",";
+				json += "\"schema\":\"" + EscapeJsonString(schema_name.ToString()) + "\",";
+				json += "\"name\":\"" + EscapeJsonString(table_name.ToString()) + "\",";
+				json += "\"type\":\"" + EscapeJsonString(obj_type.ToString()) + "\",";
 				if (row_count.IsNull()) {
 					json += "\"row_count_estimate\":null,";
 				} else {
@@ -957,16 +957,16 @@ Value DatabaseInfoToolHandler::GetDatabasesInfo() const {
 			first = false;
 
 			json += "{";
-			json += "\"name\":\"" + chunk->GetValue(0, i).ToString() + "\",";
+			json += "\"name\":\"" + EscapeJsonString(chunk->GetValue(0, i).ToString()) + "\",";
 
 			auto path = chunk->GetValue(1, i);
 			if (path.IsNull()) {
 				json += "\"path\":null,";
 			} else {
-				json += "\"path\":\"" + path.ToString() + "\",";
+				json += "\"path\":\"" + EscapeJsonString(path.ToString()) + "\",";
 			}
 
-			json += "\"type\":\"" + chunk->GetValue(2, i).ToString() + "\",";
+			json += "\"type\":\"" + EscapeJsonString(chunk->GetValue(2, i).ToString()) + "\",";
 			json += "\"readonly\":" + string(chunk->GetValue(3, i).GetValue<bool>() ? "true" : "false") + ",";
 			json += "\"user_attached\":" + string(chunk->GetValue(4, i).GetValue<bool>() ? "true" : "false");
 			json += "}";
@@ -1002,8 +1002,8 @@ Value DatabaseInfoToolHandler::GetSchemasInfo() const {
 			first = false;
 
 			json += "{";
-			json += "\"database\":\"" + chunk->GetValue(0, i).ToString() + "\",";
-			json += "\"name\":\"" + chunk->GetValue(1, i).ToString() + "\",";
+			json += "\"database\":\"" + EscapeJsonString(chunk->GetValue(0, i).ToString()) + "\",";
+			json += "\"name\":\"" + EscapeJsonString(chunk->GetValue(1, i).ToString()) + "\",";
 			json += "\"user_schema\":" + string(chunk->GetValue(2, i).GetValue<bool>() ? "true" : "false");
 			json += "}";
 		}
@@ -1041,9 +1041,9 @@ Value DatabaseInfoToolHandler::GetTablesInfo() const {
 			first = false;
 
 			json += "{";
-			json += "\"database\":\"" + chunk->GetValue(0, i).ToString() + "\",";
-			json += "\"schema\":\"" + chunk->GetValue(1, i).ToString() + "\",";
-			json += "\"name\":\"" + chunk->GetValue(2, i).ToString() + "\",";
+			json += "\"database\":\"" + EscapeJsonString(chunk->GetValue(0, i).ToString()) + "\",";
+			json += "\"schema\":\"" + EscapeJsonString(chunk->GetValue(1, i).ToString()) + "\",";
+			json += "\"name\":\"" + EscapeJsonString(chunk->GetValue(2, i).ToString()) + "\",";
 
 			auto row_count = chunk->GetValue(3, i);
 			if (row_count.IsNull()) {
@@ -1088,9 +1088,9 @@ Value DatabaseInfoToolHandler::GetViewsInfo() const {
 			first = false;
 
 			json += "{";
-			json += "\"database\":\"" + chunk->GetValue(0, i).ToString() + "\",";
-			json += "\"schema\":\"" + chunk->GetValue(1, i).ToString() + "\",";
-			json += "\"name\":\"" + chunk->GetValue(2, i).ToString() + "\",";
+			json += "\"database\":\"" + EscapeJsonString(chunk->GetValue(0, i).ToString()) + "\",";
+			json += "\"schema\":\"" + EscapeJsonString(chunk->GetValue(1, i).ToString()) + "\",";
+			json += "\"name\":\"" + EscapeJsonString(chunk->GetValue(2, i).ToString()) + "\",";
 			json += "\"column_count\":" + chunk->GetValue(3, i).ToString();
 			json += "}";
 		}
@@ -1128,7 +1128,7 @@ Value DatabaseInfoToolHandler::GetExtensionsInfo() const {
 			first = false;
 
 			json += "{";
-			json += "\"name\":\"" + chunk->GetValue(0, i).ToString() + "\",";
+			json += "\"name\":\"" + EscapeJsonString(chunk->GetValue(0, i).ToString()) + "\",";
 			json += "\"loaded\":" + string(chunk->GetValue(1, i).GetValue<bool>() ? "true" : "false") + ",";
 			json += "\"installed\":" + string(chunk->GetValue(2, i).GetValue<bool>() ? "true" : "false") + ",";
 
@@ -1136,25 +1136,14 @@ Value DatabaseInfoToolHandler::GetExtensionsInfo() const {
 			if (desc.IsNull()) {
 				json += "\"description\":null,";
 			} else {
-				// Escape quotes in description
-				string desc_str = desc.ToString();
-				string escaped;
-				for (char c : desc_str) {
-					if (c == '"')
-						escaped += "\\\"";
-					else if (c == '\\')
-						escaped += "\\\\";
-					else
-						escaped += c;
-				}
-				json += "\"description\":\"" + escaped + "\",";
+				json += "\"description\":\"" + EscapeJsonString(desc.ToString()) + "\",";
 			}
 
 			auto version = chunk->GetValue(4, i);
 			if (version.IsNull()) {
 				json += "\"version\":null";
 			} else {
-				json += "\"version\":\"" + version.ToString() + "\"";
+				json += "\"version\":\"" + EscapeJsonString(version.ToString()) + "\"";
 			}
 			json += "}";
 		}

--- a/test/sql/mcp_security_regression.test
+++ b/test/sql/mcp_security_regression.test
@@ -393,8 +393,94 @@ statement ok
 SELECT mcp_server_stop(true);
 
 # =============================================================================
+# CR-01: list_tables must JSON-escape table/schema/database names (issue #22)
+# =============================================================================
+# Create a table whose name contains a double-quote character.
+# list_tables builds JSON by hand; without EscapeJsonString the inner JSON
+# content is malformed.
+#
+# Detection: When the tool escapes the quote, the inner JSON has \"
+# which the JSON-RPC layer further escapes to \\\". We check for this
+# triple-backslash-quote sequence using chr() to avoid SQL escaping issues.
+
+statement ok
+CREATE TABLE "tbl""quote" (id INTEGER);
+
+statement ok
+SELECT mcp_server_start('memory');
+
+# With proper escaping, the response must contain tbl + \\\" + quote
+# (inner \" becomes \\\" in the JSON-RPC response)
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"list_tables","arguments":{}}}')
+  LIKE '%tbl' || chr(92) || chr(92) || chr(92) || chr(34) || 'quote%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# CR-02: database_info must JSON-escape all string fields (issue #22)
+# =============================================================================
+# database_info aggregates output from sub-methods (tables, views, etc.)
+# that all build JSON by hand. The table with a quote in its name will
+# appear in the tables section and produce malformed JSON without escaping.
+
+statement ok
+SELECT mcp_server_start('memory');
+
+# The table name must be properly escaped in database_info output
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":110,"method":"tools/call","params":{"name":"database_info","arguments":{}}}')
+  LIKE '%tbl' || chr(92) || chr(92) || chr(92) || chr(34) || 'quote%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# CR-03: export JSON mode must escape column names and values (issue #22)
+# =============================================================================
+# Create a table with a column name containing a double quote, and a value
+# containing both a backslash and a double quote.
+
+statement ok
+CREATE TABLE export_escape_test ("col""q" VARCHAR);
+
+statement ok
+INSERT INTO export_escape_test VALUES ('val\with"chars');
+
+statement ok
+SELECT mcp_server_start('memory');
+
+# Column name must be escaped: col"q → col\"q in inner JSON → col\\\"q in response
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":120,"method":"tools/call","params":{"name":"export","arguments":{"query":"SELECT * FROM export_escape_test","format":"json"}}}')
+  LIKE '%col' || chr(92) || chr(92) || chr(92) || chr(34) || 'q%';
+----
+true
+
+# Backslash in value must be escaped: val\with → val\\with in inner JSON → val\\\\with in response
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":121,"method":"tools/call","params":{"name":"export","arguments":{"query":"SELECT * FROM export_escape_test","format":"json"}}}')
+  LIKE '%val' || chr(92) || chr(92) || chr(92) || chr(92) || 'with%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
 # Cleanup
 # =============================================================================
+
+statement ok
+DROP TABLE IF EXISTS export_escape_test;
+
+statement ok
+DROP TABLE IF EXISTS "tbl""quote";
 
 statement ok
 DROP VIEW IF EXISTS sec_view;


### PR DESCRIPTION
## Summary
- Apply `EscapeJsonString()` to all user-derived string values in `ListTablesToolHandler`, `DatabaseInfoToolHandler` (all 5 sub-methods), and `ExportToolHandler::FormatData`
- Replace partial manual escape in `GetExtensionsInfo` (only handled `"` and `\`, missed control chars) with the canonical `EscapeJsonString()` function
- Add regression tests using `chr()`-based pattern matching to detect malformed inner JSON from unescaped quotes and backslashes

Closes #22

## Test plan
- [x] New tests fail before fix (confirmed: `738 passed | 1 failed`)
- [x] All 739 assertions pass after fix
- [x] Interactive verification with `json_valid()` confirms all three handlers produce valid inner JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)