### PR TITLE
Expose MCP state as queryable tables (#62)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(EXTENSION_SOURCES
   src/protocol/mcp_template.cpp
   src/protocol/mcp_pagination.cpp
   src/server/mcp_server.cpp
+  src/server/mcp_state_table_functions.cpp
   src/server/resource_providers.cpp
   src/server/tool_handlers.cpp
   src/server/memory_transport.cpp

--- a/src/duckdb_mcp_extension.cpp
+++ b/src/duckdb_mcp_extension.cpp
@@ -24,6 +24,7 @@ using namespace duckdb_yyjson;
 #include "server/tool_handlers.hpp"
 #include "result_formatter.hpp"
 #include "server/memory_transport.hpp"
+#include "server/mcp_state_table_functions.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
@@ -2248,6 +2249,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// PRAGMA mcp_config_begin / mcp_config_end — suppress scalar function output during config
 	loader.RegisterFunction(PragmaFunction::PragmaStatement("mcp_config_begin", PragmaMCPConfigBegin));
 	loader.RegisterFunction(PragmaFunction::PragmaStatement("mcp_config_end", PragmaMCPConfigEnd));
+
+	// State introspection table functions
+	RegisterMCPStateTableFunctions(loader);
 
 #ifdef __EMSCRIPTEN__
 	// Register WebMCP-specific functions (WASM only)

--- a/src/include/server/mcp_server.hpp
+++ b/src/include/server/mcp_server.hpp
@@ -81,6 +81,7 @@ public:
 	vector<string> ListResources() const;
 	shared_ptr<ResourceProvider> GetResource(const string &uri) const;
 	bool ResourceExists(const string &uri) const;
+	vector<pair<string, shared_ptr<ResourceProvider>>> GetAllResources() const;
 
 private:
 	mutable mutex registry_mutex;
@@ -95,6 +96,7 @@ public:
 	vector<string> ListTools() const;
 	shared_ptr<ToolHandler> GetTool(const string &name) const;
 	bool ToolExists(const string &name) const;
+	vector<pair<string, shared_ptr<ToolHandler>>> GetAllTools() const;
 
 private:
 	mutable mutex registry_mutex;
@@ -140,6 +142,11 @@ public:
 	bool RegisterTool(const string &name, shared_ptr<ToolHandler> handler);
 	bool UnregisterTool(const string &name);
 	vector<string> ListRegisteredTools() const;
+
+	// Bulk accessors for state introspection
+	const MCPServerConfig &GetConfig() const;
+	vector<pair<string, shared_ptr<ToolHandler>>> GetAllRegisteredTools() const;
+	vector<pair<string, shared_ptr<ResourceProvider>>> GetAllPublishedResources() const;
 
 #ifndef __EMSCRIPTEN__
 	// Main loop for stdio mode (blocks until process ends)
@@ -250,6 +257,28 @@ struct PendingResourceRegistration {
 	DatabaseInstance *db_instance;
 };
 
+// Metadata snapshot entries for state introspection table functions
+struct ToolMetadataEntry {
+	string name;
+	string description;
+	string sql_template;
+	string parameters_json;
+	string required_json;
+	string format;
+	string status; // "pending" or "active"
+	bool is_builtin = false;
+};
+
+struct ResourceMetadataEntry {
+	string uri;
+	string type;
+	string description;
+	string mime_type;
+	string source;
+	string format;
+	string status; // "pending" or "active"
+};
+
 // Per-instance server management
 class MCPServerManager {
 public:
@@ -288,6 +317,12 @@ public:
 
 	// Apply pending registrations to an external server (for foreground mode)
 	void ApplyPendingRegistrationsTo(MCPServer *external_server);
+
+	// State introspection snapshots (for table functions)
+	vector<ToolMetadataEntry> GetToolSnapshot() const;
+	vector<ResourceMetadataEntry> GetResourceSnapshot() const;
+	MCPServerConfig GetServerConfigSnapshot() const;
+	bool HasServerConfig() const;
 
 private:
 	unique_ptr<MCPServer> server;

--- a/src/include/server/mcp_state_table_functions.hpp
+++ b/src/include/server/mcp_state_table_functions.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+//! Register mcp_tools(), mcp_resources(), mcp_server_config(), and mcp_list_tools() table functions
+void RegisterMCPStateTableFunctions(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/server/tool_handlers.hpp
+++ b/src/include/server/tool_handlers.hpp
@@ -159,6 +159,14 @@ public:
 		return input_schema;
 	}
 
+	// Accessors for state introspection
+	const string &GetSqlTemplate() const {
+		return sql_template;
+	}
+	const string &GetResultFormat() const {
+		return result_format;
+	}
+
 private:
 	string tool_name;
 	string tool_description;
@@ -187,6 +195,14 @@ public:
 	}
 	ToolInputSchema GetInputSchema() const override {
 		return input_schema;
+	}
+
+	// Accessors for state introspection
+	const string &GetSqlTemplate() const {
+		return sql_template;
+	}
+	const string &GetResultFormat() const {
+		return result_format;
 	}
 
 private:

--- a/src/server/mcp_server.cpp
+++ b/src/server/mcp_server.cpp
@@ -56,6 +56,16 @@ bool ResourceRegistry::ResourceExists(const string &uri) const {
 	return resources.find(uri) != resources.end();
 }
 
+vector<pair<string, shared_ptr<ResourceProvider>>> ResourceRegistry::GetAllResources() const {
+	lock_guard<mutex> lock(registry_mutex);
+	vector<pair<string, shared_ptr<ResourceProvider>>> result;
+	result.reserve(resources.size());
+	for (const auto &pair : resources) {
+		result.emplace_back(pair.first, pair.second);
+	}
+	return result;
+}
+
 //===--------------------------------------------------------------------===//
 // ToolRegistry Implementation
 //===--------------------------------------------------------------------===//
@@ -88,6 +98,16 @@ shared_ptr<ToolHandler> ToolRegistry::GetTool(const string &name) const {
 bool ToolRegistry::ToolExists(const string &name) const {
 	lock_guard<mutex> lock(registry_mutex);
 	return tools.find(name) != tools.end();
+}
+
+vector<pair<string, shared_ptr<ToolHandler>>> ToolRegistry::GetAllTools() const {
+	lock_guard<mutex> lock(registry_mutex);
+	vector<pair<string, shared_ptr<ToolHandler>>> result;
+	result.reserve(tools.size());
+	for (const auto &pair : tools) {
+		result.emplace_back(pair.first, pair.second);
+	}
+	return result;
 }
 
 //===--------------------------------------------------------------------===//
@@ -265,6 +285,18 @@ bool MCPServer::UnregisterTool(const string &name) {
 
 vector<string> MCPServer::ListRegisteredTools() const {
 	return tool_registry.ListTools();
+}
+
+const MCPServerConfig &MCPServer::GetConfig() const {
+	return config;
+}
+
+vector<pair<string, shared_ptr<ToolHandler>>> MCPServer::GetAllRegisteredTools() const {
+	return tool_registry.GetAllTools();
+}
+
+vector<pair<string, shared_ptr<ResourceProvider>>> MCPServer::GetAllPublishedResources() const {
+	return resource_registry.GetAllResources();
 }
 
 #ifndef __EMSCRIPTEN__
@@ -978,6 +1010,143 @@ void MCPServerManager::ApplyRegistrationsTo(MCPServer *target) {
 		             static_cast<uint64_t>(pending_resources.size()));
 	}
 	pending_resources.clear();
+}
+
+//===--------------------------------------------------------------------===//
+// MCPServerManager State Introspection
+//===--------------------------------------------------------------------===//
+
+vector<ToolMetadataEntry> MCPServerManager::GetToolSnapshot() const {
+	lock_guard<mutex> lock(manager_mutex);
+	vector<ToolMetadataEntry> entries;
+
+	if (server && server->IsRunning()) {
+		// Server is running — get live tools from registry
+		auto all_tools = server->GetAllRegisteredTools();
+		entries.reserve(all_tools.size());
+		for (auto &tool_pair : all_tools) {
+			auto &handler = tool_pair.second;
+			ToolMetadataEntry entry;
+			entry.name = handler->GetName();
+			entry.description = handler->GetDescription();
+			entry.status = "active";
+
+			// Try to extract SQL-specific metadata via downcast
+			auto *sql_handler = dynamic_cast<SQLToolHandler *>(handler.get());
+			auto *exec_handler = dynamic_cast<ExecutionSQLToolHandler *>(handler.get());
+			if (sql_handler) {
+				entry.sql_template = sql_handler->GetSqlTemplate();
+				entry.format = sql_handler->GetResultFormat();
+				entry.is_builtin = false;
+			} else if (exec_handler) {
+				entry.sql_template = exec_handler->GetSqlTemplate();
+				entry.format = exec_handler->GetResultFormat();
+				entry.is_builtin = false;
+			} else {
+				// Built-in tool (query, describe, export, etc.)
+				entry.is_builtin = true;
+			}
+
+			// Serialize input schema properties as JSON
+			auto schema = handler->GetInputSchema();
+			auto *doc = JSONUtils::CreateDocument();
+			auto *props = JSONUtils::CreateObject(doc);
+			for (const auto &prop : schema.properties) {
+				auto *prop_val = JSONUtils::ValueToJSON(doc, prop.second);
+				JSONUtils::AddObject(doc, props, prop.first.c_str(), prop_val);
+			}
+			yyjson_mut_doc_set_root(doc, props);
+			entry.parameters_json = JSONUtils::Serialize(doc);
+			JSONUtils::FreeDocument(doc);
+			string req = "[";
+			for (idx_t i = 0; i < schema.required_fields.size(); i++) {
+				if (i > 0) {
+					req += ",";
+				}
+				req += "\"" + schema.required_fields[i] + "\"";
+			}
+			req += "]";
+			entry.required_json = req;
+
+			entries.push_back(std::move(entry));
+		}
+	} else {
+		// Server not running — show pending registrations
+		entries.reserve(pending_tools.size());
+		for (const auto &reg : pending_tools) {
+			ToolMetadataEntry entry;
+			entry.name = reg.name;
+			entry.description = reg.description;
+			entry.sql_template = reg.sql_template;
+			entry.parameters_json = reg.properties_json;
+			entry.required_json = reg.required_json;
+			entry.format = reg.format;
+			entry.status = "pending";
+			entry.is_builtin = false;
+			entries.push_back(std::move(entry));
+		}
+	}
+
+	return entries;
+}
+
+vector<ResourceMetadataEntry> MCPServerManager::GetResourceSnapshot() const {
+	lock_guard<mutex> lock(manager_mutex);
+	vector<ResourceMetadataEntry> entries;
+
+	if (server && server->IsRunning()) {
+		// Server is running — get live resources from registry
+		auto all_resources = server->GetAllPublishedResources();
+		entries.reserve(all_resources.size());
+		for (auto &res_pair : all_resources) {
+			ResourceMetadataEntry entry;
+			entry.uri = res_pair.first;
+			auto &provider = res_pair.second;
+			entry.description = provider->GetDescription();
+			entry.mime_type = provider->GetMimeType();
+			entry.status = "active";
+
+			// Determine type from provider class
+			if (dynamic_cast<TableResourceProvider *>(provider.get())) {
+				entry.type = "table";
+			} else if (dynamic_cast<QueryResourceProvider *>(provider.get())) {
+				entry.type = "query";
+			} else if (dynamic_cast<StaticResourceProvider *>(provider.get())) {
+				entry.type = "resource";
+			}
+
+			entries.push_back(std::move(entry));
+		}
+	} else {
+		// Server not running — show pending registrations
+		entries.reserve(pending_resources.size());
+		for (const auto &reg : pending_resources) {
+			ResourceMetadataEntry entry;
+			entry.uri = reg.uri;
+			entry.type = reg.type;
+			entry.description = reg.description;
+			entry.mime_type = reg.mime_type;
+			entry.source = reg.source;
+			entry.format = reg.format;
+			entry.status = "pending";
+			entries.push_back(std::move(entry));
+		}
+	}
+
+	return entries;
+}
+
+MCPServerConfig MCPServerManager::GetServerConfigSnapshot() const {
+	lock_guard<mutex> lock(manager_mutex);
+	if (server) {
+		return server->GetConfig();
+	}
+	return MCPServerConfig {};
+}
+
+bool MCPServerManager::HasServerConfig() const {
+	lock_guard<mutex> lock(manager_mutex);
+	return server != nullptr;
 }
 
 } // namespace duckdb

--- a/src/server/mcp_state_table_functions.cpp
+++ b/src/server/mcp_state_table_functions.cpp
@@ -1,0 +1,223 @@
+#include "server/mcp_state_table_functions.hpp"
+#include "mcp_instance_state.hpp"
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// mcp_tools() table function
+//===--------------------------------------------------------------------===//
+
+struct MCPToolsData : public GlobalTableFunctionState {
+	vector<ToolMetadataEntry> entries;
+	idx_t offset = 0;
+};
+
+static unique_ptr<FunctionData> MCPToolsBind(ClientContext &context, TableFunctionBindInput &input,
+                                             vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("sql_template");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("parameters");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("required");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("format");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("status");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("is_builtin");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	return nullptr;
+}
+
+static unique_ptr<GlobalTableFunctionState> MCPToolsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<MCPToolsData>();
+	auto &state = MCPInstanceState::Get(context);
+	result->entries = state.server_manager.GetToolSnapshot();
+	return std::move(result);
+}
+
+static void MCPToolsScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<MCPToolsData>();
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+		output.SetValue(0, count, Value(entry.name));
+		output.SetValue(1, count, Value(entry.description));
+		output.SetValue(2, count, entry.sql_template.empty() ? Value(LogicalType::VARCHAR) : Value(entry.sql_template));
+		output.SetValue(3, count, entry.parameters_json.empty() ? Value(LogicalType::VARCHAR) : Value(entry.parameters_json));
+		output.SetValue(4, count, entry.required_json.empty() ? Value(LogicalType::VARCHAR) : Value(entry.required_json));
+		output.SetValue(5, count, entry.format.empty() ? Value(LogicalType::VARCHAR) : Value(entry.format));
+		output.SetValue(6, count, Value(entry.status));
+		output.SetValue(7, count, Value::BOOLEAN(entry.is_builtin));
+		count++;
+		data.offset++;
+	}
+	output.SetCardinality(count);
+}
+
+//===--------------------------------------------------------------------===//
+// mcp_resources() table function
+//===--------------------------------------------------------------------===//
+
+struct MCPResourcesData : public GlobalTableFunctionState {
+	vector<ResourceMetadataEntry> entries;
+	idx_t offset = 0;
+};
+
+static unique_ptr<FunctionData> MCPResourcesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("uri");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("mime_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("source");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("format");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("status");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return nullptr;
+}
+
+static unique_ptr<GlobalTableFunctionState> MCPResourcesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<MCPResourcesData>();
+	auto &state = MCPInstanceState::Get(context);
+	result->entries = state.server_manager.GetResourceSnapshot();
+	return std::move(result);
+}
+
+static void MCPResourcesScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<MCPResourcesData>();
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+		output.SetValue(0, count, Value(entry.uri));
+		output.SetValue(1, count, entry.type.empty() ? Value(LogicalType::VARCHAR) : Value(entry.type));
+		output.SetValue(2, count, entry.description.empty() ? Value(LogicalType::VARCHAR) : Value(entry.description));
+		output.SetValue(3, count, entry.mime_type.empty() ? Value(LogicalType::VARCHAR) : Value(entry.mime_type));
+		output.SetValue(4, count, entry.source.empty() ? Value(LogicalType::VARCHAR) : Value(entry.source));
+		output.SetValue(5, count, entry.format.empty() ? Value(LogicalType::VARCHAR) : Value(entry.format));
+		output.SetValue(6, count, Value(entry.status));
+		count++;
+		data.offset++;
+	}
+	output.SetCardinality(count);
+}
+
+//===--------------------------------------------------------------------===//
+// mcp_server_config() table function
+//===--------------------------------------------------------------------===//
+
+struct MCPServerConfigData : public GlobalTableFunctionState {
+	vector<pair<string, string>> entries;
+	idx_t offset = 0;
+};
+
+static vector<pair<string, string>> ConfigToKVPairs(const MCPServerConfig &config, bool has_config) {
+	vector<pair<string, string>> pairs;
+	if (!has_config) {
+		return pairs;
+	}
+
+	pairs.emplace_back("transport", config.transport);
+	pairs.emplace_back("bind_address", config.bind_address);
+	pairs.emplace_back("port", to_string(config.port));
+	pairs.emplace_back("auth_token", config.auth_token.empty() ? "" : "****");
+	pairs.emplace_back("ssl_cert_path", config.ssl_cert_path);
+	pairs.emplace_back("ssl_key_path", config.ssl_key_path.empty() ? "" : "****");
+	pairs.emplace_back("enable_query_tool", config.enable_query_tool ? "true" : "false");
+	pairs.emplace_back("enable_describe_tool", config.enable_describe_tool ? "true" : "false");
+	pairs.emplace_back("enable_export_tool", config.enable_export_tool ? "true" : "false");
+	pairs.emplace_back("export_allow_file_output", config.export_allow_file_output ? "true" : "false");
+	pairs.emplace_back("enable_list_tables_tool", config.enable_list_tables_tool ? "true" : "false");
+	pairs.emplace_back("enable_database_info_tool", config.enable_database_info_tool ? "true" : "false");
+	pairs.emplace_back("enable_execute_tool", config.enable_execute_tool ? "true" : "false");
+	pairs.emplace_back("execute_allow_ddl", config.execute_allow_ddl ? "true" : "false");
+	pairs.emplace_back("execute_allow_dml", config.execute_allow_dml ? "true" : "false");
+	pairs.emplace_back("execute_allow_load", config.execute_allow_load ? "true" : "false");
+	pairs.emplace_back("execute_allow_attach", config.execute_allow_attach ? "true" : "false");
+	pairs.emplace_back("execute_allow_set", config.execute_allow_set ? "true" : "false");
+	pairs.emplace_back("cors_origins", config.cors_origins);
+	pairs.emplace_back("enable_health_endpoint", config.enable_health_endpoint ? "true" : "false");
+	pairs.emplace_back("auth_health_endpoint", config.auth_health_endpoint ? "true" : "false");
+	pairs.emplace_back("default_result_format", config.default_result_format);
+	pairs.emplace_back("max_connections", to_string(config.max_connections));
+	pairs.emplace_back("request_timeout_seconds", to_string(config.request_timeout_seconds));
+	pairs.emplace_back("max_requests", to_string(config.max_requests));
+	pairs.emplace_back("require_auth", config.require_auth ? "true" : "false");
+	pairs.emplace_back("allow_direct_requests", config.allow_direct_requests ? "true" : "false");
+
+	return pairs;
+}
+
+static unique_ptr<FunctionData> MCPServerConfigBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("key");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("value");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return nullptr;
+}
+
+static unique_ptr<GlobalTableFunctionState> MCPServerConfigInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<MCPServerConfigData>();
+	auto &state = MCPInstanceState::Get(context);
+	auto config = state.server_manager.GetServerConfigSnapshot();
+	bool has_config = state.server_manager.HasServerConfig();
+	result->entries = ConfigToKVPairs(config, has_config);
+	return std::move(result);
+}
+
+static void MCPServerConfigScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<MCPServerConfigData>();
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+		output.SetValue(0, count, Value(entry.first));
+		output.SetValue(1, count, Value(entry.second));
+		count++;
+		data.offset++;
+	}
+	output.SetCardinality(count);
+}
+
+//===--------------------------------------------------------------------===//
+// Registration
+//===--------------------------------------------------------------------===//
+
+void RegisterMCPStateTableFunctions(ExtensionLoader &loader) {
+	// mcp_tools()
+	TableFunction mcp_tools("mcp_tools", {}, MCPToolsScan);
+	mcp_tools.bind = MCPToolsBind;
+	mcp_tools.init_global = MCPToolsInit;
+	loader.RegisterFunction(mcp_tools);
+
+	// mcp_list_tools() — alias for mcp_tools()
+	TableFunction mcp_list_tools("mcp_list_tools", {}, MCPToolsScan);
+	mcp_list_tools.bind = MCPToolsBind;
+	mcp_list_tools.init_global = MCPToolsInit;
+	loader.RegisterFunction(mcp_list_tools);
+
+	// mcp_resources()
+	TableFunction mcp_resources("mcp_resources", {}, MCPResourcesScan);
+	mcp_resources.bind = MCPResourcesBind;
+	mcp_resources.init_global = MCPResourcesInit;
+	loader.RegisterFunction(mcp_resources);
+
+	// mcp_server_config()
+	TableFunction mcp_server_config("mcp_server_config", {}, MCPServerConfigScan);
+	mcp_server_config.bind = MCPServerConfigBind;
+	mcp_server_config.init_global = MCPServerConfigInit;
+	loader.RegisterFunction(mcp_server_config);
+}
+
+} // namespace duckdb

--- a/test/sql/mcp_state_tables.test
+++ b/test/sql/mcp_state_tables.test
@@ -1,0 +1,205 @@
+# name: test/sql/mcp_state_tables.test
+# description: Test MCP state introspection table functions
+# group: [sql]
+
+# Load the MCP extension
+require duckdb_mcp
+
+statement ok
+LOAD duckdb_mcp;
+
+# =============================================================================
+# SETUP: Force clean state
+# =============================================================================
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# SECTION 1: Empty state before any registrations
+# =============================================================================
+
+# mcp_tools() should return zero rows before any registrations
+query I
+SELECT count(*) FROM mcp_tools();
+----
+0
+
+# mcp_list_tools() alias should also return zero rows
+query I
+SELECT count(*) FROM mcp_list_tools();
+----
+0
+
+# mcp_resources() should return zero rows
+query I
+SELECT count(*) FROM mcp_resources();
+----
+0
+
+# mcp_server_config() should return zero rows when server not started
+query I
+SELECT count(*) FROM mcp_server_config();
+----
+0
+
+# =============================================================================
+# SECTION 2: Pending tools visible before server start
+# =============================================================================
+
+# Create test table for SQL tool
+statement ok
+CREATE TABLE IF NOT EXISTS test_products AS SELECT 1 as id, 'Widget' as name;
+
+# Publish tools using PRAGMA (avoids double-evaluation of scalar function side effects)
+statement ok
+PRAGMA mcp_publish_tool('get_product', 'Get product by ID', 'SELECT * FROM test_products WHERE id = $id', '{"id":{"type":"integer","description":"Product ID"}}', '["id"]');
+
+# mcp_tools() should now show the pending tool
+query I
+SELECT count(*) FROM mcp_tools();
+----
+1
+
+# Check pending tool metadata
+query TT
+SELECT name, status FROM mcp_tools();
+----
+get_product	pending
+
+# Check sql_template is populated for pending tools
+query I
+SELECT sql_template IS NOT NULL FROM mcp_tools() WHERE name = 'get_product';
+----
+true
+
+# mcp_list_tools() should return the same result
+query TT
+SELECT name, status FROM mcp_list_tools();
+----
+get_product	pending
+
+# Publish another tool
+statement ok
+PRAGMA mcp_publish_tool('list_products', 'List all products', 'SELECT * FROM test_products', '{}', '[]', 'markdown');
+
+# Should now have 2 pending tools
+query I
+SELECT count(*) FROM mcp_tools() WHERE status = 'pending';
+----
+2
+
+# =============================================================================
+# SECTION 3: Pending resources visible before server start
+# =============================================================================
+
+# Publish a table resource
+statement ok
+PRAGMA mcp_publish_table('test_products', 'data://products', 'json');
+
+# Publish a static resource
+statement ok
+PRAGMA mcp_publish_resource('data://readme', 'Hello World', 'text/plain', 'A readme');
+
+# mcp_resources() should show 2 pending resources
+query I
+SELECT count(*) FROM mcp_resources();
+----
+2
+
+# Check resource metadata
+query TT
+SELECT uri, status FROM mcp_resources() ORDER BY uri;
+----
+data://products	pending
+data://readme	pending
+
+# =============================================================================
+# SECTION 4: After server start — tools become active
+# =============================================================================
+
+# Start server with memory transport
+statement ok
+SELECT mcp_server_start('memory');
+
+# User-defined tools should be present and not marked as built-in
+query I
+SELECT count(*) FROM mcp_tools() WHERE name = 'get_product' AND is_builtin = false;
+----
+1
+
+# Built-in tools should be present
+query I
+SELECT count(*) FROM mcp_tools() WHERE is_builtin = true AND name = 'query';
+----
+1
+
+# All tools should be active after server start (no pending)
+query I
+SELECT count(*) FROM mcp_tools() WHERE status = 'pending';
+----
+0
+
+# All tools should be active (built-in + user-defined)
+query I
+SELECT count(*) FROM mcp_tools() WHERE status = 'active';
+----
+7
+
+# =============================================================================
+# SECTION 5: After server start — resources become active
+# =============================================================================
+
+# Resources should be present
+query I
+SELECT count(*) FROM mcp_resources();
+----
+2
+
+# =============================================================================
+# SECTION 6: Server config visible after start
+# =============================================================================
+
+# mcp_server_config() should have entries
+query I
+SELECT count(*) > 0 FROM mcp_server_config();
+----
+true
+
+# Check transport is memory
+query T
+SELECT value FROM mcp_server_config() WHERE key = 'transport';
+----
+memory
+
+# Check some boolean config values
+query T
+SELECT value FROM mcp_server_config() WHERE key = 'enable_query_tool';
+----
+true
+
+# =============================================================================
+# SECTION 7: SQL composability
+# =============================================================================
+
+# Filter tools by type
+query I
+SELECT count(*) FROM mcp_tools() WHERE is_builtin = false;
+----
+2
+
+# SELECT specific columns
+query T
+SELECT name FROM mcp_tools() WHERE name = 'list_products';
+----
+list_products
+
+# =============================================================================
+# SECTION 8: Clean up
+# =============================================================================
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+DROP TABLE IF EXISTS test_products;


### PR DESCRIPTION
## Summary
- Add `mcp_tools()`, `mcp_resources()`, `mcp_server_config()` table functions for introspecting MCP server state
- Add no-arg `mcp_list_tools()` alias per issue request
- Tables reflect both queued (pre-start) and active (post-start) state

Closes #62

## Test plan
- [x] New SQL logic test (`test/sql/mcp_state_tables.test`) covers empty state, pending, active, config, and composability
- [x] All 30 existing MCP tests pass (1060 assertions)
- [x] CI green on all platforms (Linux, macOS, Windows, WASM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)