### PR TITLE
Refresh user-facing docs for v2.1 features and consistency

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -32,8 +32,8 @@ cat test-calls.ldjson | duckdb -init init-mcp-server.sql 2>/dev/null | jq .
 The simplest possible MCP server - an empty database with default tools.
 
 ```sql
-LOAD 'duckdb_mcp';
-SELECT mcp_server_start('stdio', 'localhost', 0, '{}');
+LOAD duckdb_mcp;
+PRAGMA mcp_server_start('stdio');
 ```
 
 **Use case:** Testing MCP client connections, learning the basics.
@@ -51,7 +51,7 @@ Demonstrates server configuration options:
 - Tool enable/disable settings
 
 ```sql
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
+PRAGMA mcp_server_start('stdio', '{
     "enable_execute_tool": false,
     "default_result_format": "markdown"
 }');
@@ -96,7 +96,7 @@ Shows security hardening:
 - Limited tool exposure
 
 ```sql
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
+PRAGMA mcp_server_start('stdio', '{
     "enable_query_tool": true,
     "enable_execute_tool": false,
     "enable_export_tool": false
@@ -113,15 +113,17 @@ SELECT mcp_server_start('stdio', 'localhost', 0, '{
 
 Demonstrates creating custom tools:
 
-- Simple parameterized queries
-- DuckDB macros as tools
+- Simple parameterized queries via `mcp_publish_tool`
+- Multi-statement tools via `mcp_publish_execution_tool` (v2.0+)
+- DuckDB macros as tool targets
 - Multiple output formats
 
 ```sql
+-- Single-statement tool backed by a macro
 CREATE MACRO product_search(term) AS TABLE
     SELECT * FROM products WHERE name ILIKE '%' || term || '%';
 
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'search',
     'Search products',
     'SELECT * FROM product_search($query)',
@@ -129,7 +131,22 @@ SELECT mcp_publish_tool(
     '["query"]',
     'markdown'
 );
+
+-- Multi-statement tool: stage a temp table, then report on it
+PRAGMA mcp_publish_execution_tool(
+    'category_report',
+    'Build and report on products in a category',
+    'CREATE OR REPLACE TEMP TABLE staged AS
+        SELECT * FROM products WHERE category = $cat;
+     SELECT name, price FROM staged ORDER BY price DESC',
+    '{"cat": {"type": "string"}}',
+    '["cat"]',
+    '{"cat": "string"}',
+    'markdown'
+);
 ```
+
+See the [Custom Tools guide](guides/custom-tools.md#multi-statement-tools) for when to reach for `mcp_publish_execution_tool` instead of the single-statement form.
 
 **Use case:** Building domain-specific APIs.
 
@@ -259,7 +276,7 @@ Use the examples as templates:
 -- init-mcp-server.sql
 
 -- Load extension
-LOAD 'duckdb_mcp';
+LOAD duckdb_mcp;
 
 -- Create your schema
 CREATE TABLE my_data (...);
@@ -270,8 +287,8 @@ COPY my_data FROM 'data.csv';
 -- Create views
 CREATE VIEW my_summary AS SELECT ...;
 
--- Publish custom tools
-SELECT mcp_publish_tool(
+-- Publish custom tools (PRAGMA is silent — keeps init output clean)
+PRAGMA mcp_publish_tool(
     'my_tool',
     'Description of what it does',
     'SELECT * FROM my_data WHERE field = $param',
@@ -281,7 +298,7 @@ SELECT mcp_publish_tool(
 );
 
 -- Start server
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
+PRAGMA mcp_server_start('stdio', '{
     "enable_execute_tool": false,
     "default_result_format": "markdown"
 }');

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,26 +4,37 @@ This guide will get you up and running with the DuckDB MCP extension in just a f
 
 ## Installation
 
+### From the DuckDB Community Extensions repository
+
+The easiest way is to install from the official community registry:
+
+```sql
+INSTALL duckdb_mcp FROM community;
+LOAD duckdb_mcp;
+```
+
+This pulls a prebuilt binary for your DuckDB version and platform. No compilation required.
+
 ### Building from Source
 
+If you need a development build or an unreleased branch:
+
 ```bash
-# Clone the repository
-git clone https://github.com/teague/duckdb_mcp.git
+# Clone the repository (recursively — submodules are required)
+git clone --recursive https://github.com/teaguesterling/duckdb_mcp.git
 cd duckdb_mcp
 
 # Build the extension
 make
 
-# Run DuckDB with the extension
+# Run DuckDB with the extension preloaded
 ./build/release/duckdb
 ```
 
-### Loading the Extension
-
-Once built, load the extension in DuckDB:
+Source builds load the extension from disk:
 
 ```sql
-LOAD 'duckdb_mcp';
+LOAD 'build/release/extension/duckdb_mcp/duckdb_mcp.duckdb_extension';
 ```
 
 ## Quick Start: Running as an MCP Server
@@ -35,8 +46,8 @@ The most common use case is running DuckDB as an MCP server that AI assistants c
 Create a file called `init-server.sql`:
 
 ```sql
--- Load the extension
-LOAD 'build/release/duckdb_mcp.duckdb_extension';
+-- Load the extension (installed via INSTALL FROM community)
+LOAD duckdb_mcp;
 
 -- Create some sample data
 CREATE TABLE products (
@@ -86,11 +97,11 @@ When running as an MCP server, DuckDB exposes these tools to clients:
 
 | Tool | Description |
 |------|-------------|
-| `query` | Execute SQL SELECT queries |
+| `query` | Execute read-only SQL queries (formats: `json`, `jsonl`, `csv`, `markdown`, `text`) |
 | `describe` | Get table or query schema information |
 | `list_tables` | List all tables and views |
 | `database_info` | Get database overview (schemas, tables, extensions) |
-| `export` | Export query results to files |
+| `export` | Export query results inline or to a file (file output disabled by default) |
 | `execute` | Run DDL/DML statements (disabled by default) |
 
 ### Example: Query Tool
@@ -119,7 +130,7 @@ You can also use DuckDB to connect to external MCP servers.
 
 ```sql
 -- Load the extension
-LOAD 'duckdb_mcp';
+LOAD duckdb_mcp;
 
 -- Attach an MCP server
 ATTACH 'python3' AS data_server (

--- a/docs/guides/client-usage.md
+++ b/docs/guides/client-usage.md
@@ -18,7 +18,7 @@ When acting as an MCP client, DuckDB can:
 Use the `ATTACH` statement to connect to an MCP server:
 
 ```sql
-LOAD 'duckdb_mcp';
+LOAD duckdb_mcp;
 
 ATTACH 'python3' AS data_server (
     TYPE mcp,

--- a/docs/guides/custom-tools.md
+++ b/docs/guides/custom-tools.md
@@ -277,6 +277,72 @@ PRAGMA mcp_publish_tool(
 );
 ```
 
+## Multi-Statement Tools
+
+`mcp_publish_tool` runs a single SQL statement. When you need to run several statements in sequence — set a session variable, create a temp table, then query it — use `mcp_publish_execution_tool` instead. It takes one extra argument, `bindings`, that declares how each tool argument maps to prepared-statement parameters per statement. The result of the last statement is what the tool returns.
+
+### When to Use It
+
+Reach for `mcp_publish_execution_tool` when your tool needs any of:
+
+- `SET VARIABLE` followed by a query that reads it via `getvariable()`
+- `CREATE TEMP TABLE` / `CREATE TEMP VIEW` followed by a query against it
+- A sequence of DDL or pragma statements that prepare state for a final `SELECT`
+
+For everything else, stick with `mcp_publish_tool` — it's simpler and the single-statement path has less ceremony.
+
+### SET VARIABLE Example
+
+```sql
+PRAGMA mcp_publish_execution_tool(
+    'high_value_sales',
+    'List sales above a configurable threshold',
+    'SET VARIABLE min_amount = $threshold;
+     SELECT * FROM sales
+      WHERE amount > getvariable(''min_amount'')
+      ORDER BY amount DESC',
+    '{"threshold": {"type": "number", "description": "Minimum sale amount"}}',
+    '["threshold"]',
+    '[{}, {"threshold": "number"}]'  -- first stmt needs no params, second binds $threshold
+);
+```
+
+### Temp Table Staging Example
+
+```sql
+PRAGMA mcp_publish_execution_tool(
+    'category_price_report',
+    'Build and report on products in a category',
+    'CREATE OR REPLACE TEMP TABLE staged AS
+        SELECT * FROM products WHERE category = $cat;
+     SELECT name, price,
+            price - AVG(price) OVER () as price_vs_avg
+       FROM staged
+      ORDER BY price DESC',
+    '{"cat": {"type": "string", "description": "Product category"}}',
+    '["cat"]',
+    '{"cat": "string"}',  -- object form: bind $cat in every statement that references it
+    'markdown'
+);
+```
+
+### Bindings: Object vs Array Form
+
+The `bindings` argument tells the execution engine how to prepare each statement. Two shapes are supported:
+
+- **Object form** `{"q": "string"}` — apply the same parameter types to every statement. Simplest; use when every statement references the same parameters.
+- **Array form** `[{}, {"q": "string"}]` — one entry per statement, in order. Use when only some statements reference parameters (e.g., a `SET VARIABLE` followed by a query that uses `getvariable()` — the first statement binds `$threshold` directly, the second doesn't bind anything new).
+
+The array length must match the number of semicolon-separated statements in your template.
+
+!!! note "Parameter types"
+    Binding type names (`"string"`, `"integer"`, `"number"`, `"boolean"`) are the DuckDB-side types used when preparing each statement. They should match the JSON Schema `type` values in your `properties` argument.
+
+!!! tip "Falling back to interpolation"
+    If a statement can't be prepared (for example, a macro invocation), the execution tool falls back to safe string interpolation for that statement. You generally don't need to think about this — but it means the function works with macro-based tools as well.
+
+See [`mcp_publish_execution_tool` in the server reference](../reference/server.md#mcp_publish_execution_tool) for the complete argument list.
+
 ## Security Considerations
 
 ### Input Validation

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -19,10 +19,10 @@ The `execute` tool allows DDL/DML operations (CREATE, INSERT, UPDATE, DELETE). I
 
 ```sql
 -- Default: execute is disabled
-SELECT mcp_server_start('stdio', 'localhost', 0, '{}');
+PRAGMA mcp_server_start('stdio');
 
 -- Only enable if you trust your clients
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
+PRAGMA mcp_server_start('stdio', '{
     "enable_execute_tool": true
 }');
 ```
@@ -39,7 +39,7 @@ SELECT mcp_server_start('stdio', 'localhost', 0, '{
 If you need the execute tool, restrict it to only the statement types you need:
 
 ```sql
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
+PRAGMA mcp_server_start('stdio', '{
     "enable_execute_tool": true,
     "execute_allow_ddl": true,
     "execute_allow_dml": true,
@@ -70,7 +70,7 @@ ATTACH 'mydata.duckdb' AS main (READ_ONLY);
 Only enable the tools you need:
 
 ```sql
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
+PRAGMA mcp_server_start('stdio', '{
     "enable_query_tool": true,
     "enable_describe_tool": true,
     "enable_list_tables_tool": true,
@@ -85,13 +85,8 @@ SELECT mcp_server_start('stdio', 'localhost', 0, '{
 Instead of exposing the general `query` tool, create specific tools:
 
 ```sql
--- Disable general query
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
-    "enable_query_tool": false
-}');
-
--- Publish specific, safe tools
-SELECT mcp_publish_tool(
+-- Publish specific, safe tools before starting the server
+PRAGMA mcp_publish_tool(
     'get_public_stats',
     'Get aggregated public statistics',
     'SELECT category, COUNT(*) as count, AVG(price) as avg_price
@@ -100,6 +95,11 @@ SELECT mcp_publish_tool(
     '{}',
     '[]'
 );
+
+-- Start the server with the general query tool disabled
+PRAGMA mcp_server_start('stdio', '{
+    "enable_query_tool": false
+}');
 ```
 
 ### Validate and Sanitize Inputs
@@ -107,7 +107,7 @@ SELECT mcp_publish_tool(
 While parameters are safely substituted (not concatenated), add SQL-level validation:
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'safe_lookup',
     'Lookup item by numeric ID only',
     'SELECT * FROM items WHERE id = CAST($id AS INTEGER) LIMIT 1',
@@ -121,7 +121,7 @@ SELECT mcp_publish_tool(
 Prevent large data exfiltration:
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'list_items',
     'List items (max 100)',
     'SELECT * FROM items LIMIT LEAST($limit, 100)',
@@ -135,7 +135,7 @@ SELECT mcp_publish_tool(
 CORS is **disabled by default**. If you need browser-based clients, configure specific origins:
 
 ```sql
-SELECT mcp_server_start('http', 'localhost', 8080, '{
+PRAGMA mcp_server_start('http', 'localhost', 8080, '{
     "cors_origins": "https://app.example.com,https://admin.example.com"
 }');
 ```
@@ -148,7 +148,7 @@ SELECT mcp_server_start('http', 'localhost', 8080, '{
 The `/health` endpoint is enabled by default and unauthenticated. In security-sensitive environments, either require auth or disable it:
 
 ```sql
-SELECT mcp_server_start('http', 'localhost', 8080, '{
+PRAGMA mcp_server_start('http', 'localhost', 8080, '{
     "auth_token": "secret",
     "auth_health_endpoint": true
 }');
@@ -157,7 +157,7 @@ SELECT mcp_server_start('http', 'localhost', 8080, '{
 Or disable entirely:
 
 ```sql
-SELECT mcp_server_start('http', 'localhost', 8080, '{
+PRAGMA mcp_server_start('http', 'localhost', 8080, '{
     "enable_health_endpoint": false
 }');
 ```
@@ -167,7 +167,7 @@ SELECT mcp_server_start('http', 'localhost', 8080, '{
 For HTTP transport, always configure an auth token in production:
 
 ```sql
-SELECT mcp_server_start('http', 'localhost', 8080, '{
+PRAGMA mcp_server_start('http', 'localhost', 8080, '{
     "auth_token": "your-secret-token",
     "require_auth": true
 }');
@@ -224,7 +224,7 @@ If you only need client functionality, disable serving entirely:
 SET mcp_disable_serving = true;
 
 -- Now mcp_server_start() will fail
-SELECT mcp_server_start('stdio', 'localhost', 0, '{}');
+PRAGMA mcp_server_start('stdio');
 -- Error: MCP serving is disabled
 ```
 
@@ -236,7 +236,7 @@ Don't hardcode secrets in init scripts. Use environment variables:
 
 ```sql
 -- init-server.sql
-LOAD 'duckdb_mcp';
+LOAD duckdb_mcp;
 
 -- Get API key from environment
 CREATE OR REPLACE MACRO get_env(name) AS (
@@ -244,7 +244,7 @@ CREATE OR REPLACE MACRO get_env(name) AS (
 );
 
 -- Use in queries
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'call_api',
     'Call external API',
     'SELECT http_get(''https://api.example.com?key='' || get_env(''API_KEY''))',
@@ -297,7 +297,7 @@ If using HTTP or HTTPS transport:
 
 ```sql
 -- Bind to localhost only
-SELECT mcp_server_start('http', '127.0.0.1', 8080, '{}');
+PRAGMA mcp_server_start('http', '127.0.0.1', 8080, '{}');
 
 -- NOT: '0.0.0.0' which exposes to all interfaces
 ```

--- a/docs/guides/server-usage.md
+++ b/docs/guides/server-usage.md
@@ -16,7 +16,7 @@ When running as an MCP server, DuckDB:
 ### Basic Server
 
 ```sql
-LOAD 'duckdb_mcp';
+LOAD duckdb_mcp;
 
 -- Start with default settings (PRAGMA produces no output)
 PRAGMA mcp_server_start('stdio');
@@ -270,7 +270,7 @@ Create an init script for your server. Use `PRAGMA` syntax for side-effectful op
 -- init-server.sql
 
 -- Load extension
-LOAD 'duckdb_mcp';
+LOAD duckdb_mcp;
 
 -- Create schema
 CREATE TABLE IF NOT EXISTS products (
@@ -340,9 +340,11 @@ Now Claude can:
 - Use your custom tools
 - Read published resources
 
-## Monitoring
+## Monitoring and Introspection
 
-Check server status:
+### Server status
+
+For request/response counters and transport state:
 
 ```sql
 SELECT mcp_server_status();
@@ -358,6 +360,41 @@ Returns:
     "responses_sent": 42,
     "errors_returned": 0
 }
+```
+
+### Inspecting published state
+
+The v2.1 state introspection table functions let you query what the server has registered — tools, resources, and effective configuration — as normal SQL tables:
+
+```sql
+-- What tools are published? Which are user-defined vs built-in?
+SELECT name, status, is_builtin FROM mcp_tools();
+
+-- What resources are available to clients?
+SELECT uri, type, status FROM mcp_resources();
+
+-- What's the effective server configuration?
+SELECT key, value FROM mcp_server_config() WHERE key LIKE 'enable_%';
+```
+
+These functions work **both before and after** `mcp_server_start()` — entries you publish in an init script show up as `status = 'pending'` until the server starts, then flip to `'active'`. This makes them useful for init script validation:
+
+```sql
+-- Verify all expected user tools published successfully
+SELECT COUNT(*) AS user_tool_count
+FROM mcp_tools()
+WHERE NOT is_builtin AND status IN ('pending', 'active');
+```
+
+See the [State Introspection reference](../reference/server.md#state-introspection) for full schemas and more examples.
+
+### Diagnostics
+
+For version and log level info (useful in bug reports):
+
+```sql
+SELECT mcp_get_diagnostics();
+-- {"log_level":"info","extension_version":"2.1.0","logging_available":true}
 ```
 
 ## Best Practices

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,20 +36,20 @@ SELECT mcp_call_tool('data_server', 'process_data', '{"table": "sales"}');
 Expose your DuckDB database as an MCP server for AI assistants:
 
 ```sql
--- Start the MCP server
-SELECT mcp_server_start('stdio', 'localhost', 0, '{}');
-
 -- Publish a table as a resource
-SELECT mcp_publish_table('products', 'data://products', 'json');
+PRAGMA mcp_publish_table('products', 'data://products', 'json');
 
 -- Publish a custom tool
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'search_products',
     'Search products by name',
     'SELECT * FROM products WHERE name ILIKE ''%'' || $query || ''%''',
     '{"query": {"type": "string", "description": "Search term"}}',
     '["query"]'
 );
+
+-- Start the MCP server (stdio for CLI integration)
+PRAGMA mcp_server_start('stdio');
 ```
 
 ## Quick Links
@@ -115,7 +115,7 @@ JOIN read_csv('mcp://geo_server/countries.csv') c ON s.country_code = c.code;
 Expose domain-specific SQL queries as tools for AI assistants:
 
 ```sql
-SELECT mcp_publish_tool(
+PRAGMA mcp_publish_tool(
     'revenue_by_region',
     'Get revenue breakdown by region for a date range',
     'SELECT region, SUM(amount) as revenue
@@ -135,4 +135,4 @@ SELECT mcp_publish_tool(
 
 ## License
 
-MIT License - see [LICENSE](https://github.com/teague/duckdb_mcp/blob/main/LICENSE) for details.
+MIT License - see [LICENSE](https://github.com/teaguesterling/duckdb_mcp/blob/main/LICENSE) for details.

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -166,6 +166,9 @@ List available tools from an MCP server.
 mcp_list_tools(server_name [, cursor]) → VARCHAR (JSON)
 ```
 
+!!! note "Scalar vs table form"
+    This is the **scalar** client form — it returns a JSON string describing tools on a remote MCP server. A separate no-argument **table** function `mcp_list_tools()` exists as a convenience alias for `mcp_tools()` (server-side introspection of local publications). See [State Introspection](server.md#mcp_list_tools) in the server reference. DuckDB disambiguates the two by arity.
+
 **Parameters:**
 
 | Parameter | Type | Description |
@@ -222,7 +225,9 @@ SELECT json_extract(
 
 ---
 
-## Prompt Functions
+## Remote Prompt Functions
+
+These functions retrieve prompts from **remote** MCP servers that DuckDB is attached to. For registering and serving prompt templates from your own DuckDB instance, see [Prompt Templates](server.md#prompt-templates) in the server reference.
 
 ### mcp_list_prompts
 
@@ -256,75 +261,6 @@ mcp_get_prompt(server_name, prompt_name, arguments) → VARCHAR (JSON)
 
 ```sql
 SELECT mcp_get_prompt('ai_server', 'code_review', '{"language": "python"}');
-```
-
----
-
-## Local Prompt Templates
-
-Manage reusable prompt templates locally within DuckDB.
-
-### mcp_register_prompt_template
-
-Register a new prompt template.
-
-```sql
-mcp_register_prompt_template(name, description, content) → VARCHAR
-```
-
-**Parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `name` | VARCHAR | Unique template name |
-| `description` | VARCHAR | Human-readable description |
-| `content` | VARCHAR | Template content with `{variable}` placeholders |
-
-**Example:**
-
-```sql
-SELECT mcp_register_prompt_template(
-    'sql_query',
-    'Generate a SQL query',
-    'Write a SQL query to {action} from the {table} table where {condition}.'
-);
-```
-
----
-
-### mcp_list_prompt_templates
-
-List all registered local prompt templates.
-
-```sql
-mcp_list_prompt_templates() → VARCHAR (JSON)
-```
-
----
-
-### mcp_render_prompt_template
-
-Render a prompt template with arguments.
-
-```sql
-mcp_render_prompt_template(name, arguments) → VARCHAR
-```
-
-**Parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `name` | VARCHAR | Template name |
-| `arguments` | VARCHAR | JSON object mapping variable names to values |
-
-**Example:**
-
-```sql
-SELECT mcp_render_prompt_template(
-    'sql_query',
-    '{"action": "count users", "table": "users", "condition": "created_at > ''2024-01-01''"}'
-);
--- Returns: "Write a SQL query to count users from the users table where created_at > '2024-01-01'."
 ```
 
 ---

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,7 +7,7 @@ This page documents all configuration options for the DuckDB MCP extension.
 Configuration is passed as a JSON object to `mcp_server_start()`:
 
 ```sql
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
+PRAGMA mcp_server_start('stdio', '{
     "enable_query_tool": true,
     "enable_execute_tool": false,
     "default_result_format": "markdown"
@@ -75,7 +75,7 @@ When `enable_execute_tool` is `true`, you can control which statement types are 
 **Example: Read-only server with minimal tools**
 
 ```sql
-SELECT mcp_server_start('stdio', 'localhost', 0, '{
+PRAGMA mcp_server_start('stdio', '{
     "enable_query_tool": true,
     "enable_describe_tool": true,
     "enable_list_tables_tool": true,
@@ -260,7 +260,7 @@ Use `PRAGMA` syntax for side-effectful operations — it produces no output, kee
 
 ```sql
 -- 1. Load extension
-LOAD 'duckdb_mcp';
+LOAD duckdb_mcp;
 
 -- 2. Set up database
 CREATE TABLE IF NOT EXISTS products (
@@ -288,7 +288,7 @@ PRAGMA mcp_publish_table('products');
 -- 4. Configure (optional)
 -- SET allowed_mcp_commands = '...';
 
--- 5. Start server
+-- 5. Start server (PRAGMA — silent, keeps init output clean)
 PRAGMA mcp_server_start('stdio', '{"default_result_format": "markdown"}');
 ```
 

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -232,7 +232,7 @@ SELECT mcp_publish_resource(
 -- Publish with defaults (text/plain, no description)
 SELECT mcp_publish_resource(
     'info://version',
-    'v1.3.2',
+    'v2.1.0',
     NULL,
     NULL
 );
@@ -400,6 +400,253 @@ SELECT mcp_publish_execution_tool(
 
 ---
 
+## State Introspection
+
+Added in v2.1, these table functions expose the running server's published tools, resources, and configuration as queryable tables. They follow DuckDB's "everything is a table" philosophy and work **both before and after** `mcp_server_start()` is called — entries registered before start appear with `status = 'pending'` (queued), and active entries appear with `status = 'active'`.
+
+Typical uses:
+
+- **Init script validation** — assert that every tool/resource you expected to publish is actually registered
+- **Auto-generated help** — render a tool catalog for client-side discovery
+- **Diagnostics** — inspect effective configuration without parsing the `mcp_server_status()` JSON
+- **SQL composability** — join tool metadata with other tables, filter by status, etc.
+
+### mcp_tools
+
+Table function listing all published tools — both user-published (via `mcp_publish_tool` / `mcp_publish_execution_tool`) and server built-ins.
+
+```sql
+SELECT * FROM mcp_tools();
+```
+
+**Schema:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `name` | VARCHAR | Tool name |
+| `description` | VARCHAR | Human-readable description |
+| `sql_template` | VARCHAR | SQL template for user-published tools; NULL for built-ins |
+| `parameters` | VARCHAR | JSON Schema `properties` object |
+| `required` | VARCHAR | JSON array of required parameter names |
+| `format` | VARCHAR | Output format |
+| `status` | VARCHAR | `pending` (queued), `active` (registered on a running server), or `error` |
+| `is_builtin` | BOOLEAN | `true` for server-provided tools (`query`, `describe`, etc.), `false` for user-published |
+
+**Example — verify init script published what you expected:**
+
+```sql
+-- After your init script runs
+SELECT name, status, is_builtin FROM mcp_tools() WHERE NOT is_builtin ORDER BY name;
+
+-- Assert every expected tool is registered
+SELECT COUNT(*) FILTER (WHERE status = 'pending' OR status = 'active') AS published,
+       COUNT(*) FILTER (WHERE status = 'error')                         AS failed
+FROM mcp_tools()
+WHERE NOT is_builtin;
+```
+
+---
+
+### mcp_list_tools
+
+No-argument alias for `mcp_tools()`. Provided as a convenience for symmetry with the client-side `mcp_list_tools(server_name)` scalar function.
+
+```sql
+SELECT * FROM mcp_list_tools();
+```
+
+Schema is identical to `mcp_tools()`. Use whichever name reads better in context — they are interchangeable.
+
+!!! note "Scalar vs table form"
+    `mcp_list_tools(server_name)` (one VARCHAR argument) is the **client** function that queries a remote MCP server. The no-arg table form shown here is the **server** introspection function for the local DuckDB instance. Both names coexist because DuckDB's function registry disambiguates by arity.
+
+---
+
+### mcp_resources
+
+Table function listing all published resources — tables, queries, and static content.
+
+```sql
+SELECT * FROM mcp_resources();
+```
+
+**Schema:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `uri` | VARCHAR | Resource URI (e.g. `data://tables/products`) |
+| `type` | VARCHAR | Resource type: `table`, `query`, or `resource` |
+| `description` | VARCHAR | Human-readable description |
+| `mime_type` | VARCHAR | MIME type (e.g. `application/json`, `text/plain`) |
+| `source` | VARCHAR | Source table name, SQL query, or inline content preview |
+| `format` | VARCHAR | Output format |
+| `status` | VARCHAR | `pending`, `active`, or `error` |
+
+**Example — list everything a client would see:**
+
+```sql
+SELECT uri, type, mime_type FROM mcp_resources() WHERE status = 'active';
+```
+
+---
+
+### mcp_server_config
+
+Table function returning the effective server configuration as key-value pairs.
+
+```sql
+SELECT * FROM mcp_server_config();
+```
+
+**Schema:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `key` | VARCHAR | Configuration key (e.g. `enable_execute_tool`) |
+| `value` | VARCHAR | Stringified value — booleans as `true`/`false`, numbers as decimal strings |
+
+Every option documented in [Configuration Reference](configuration.md) is available as a row. Before the server starts this reflects the pending config; after start it reflects the live server's config.
+
+**Example — sanity-check a hardened server:**
+
+```sql
+SELECT key, value
+FROM mcp_server_config()
+WHERE key IN (
+    'enable_execute_tool',
+    'execute_allow_load',
+    'execute_allow_attach',
+    'cors_origins',
+    'require_auth'
+);
+```
+
+**Example — filter to just the `enable_*` flags:**
+
+```sql
+SELECT key, value
+FROM mcp_server_config()
+WHERE key LIKE 'enable_%'
+ORDER BY key;
+```
+
+---
+
+## Diagnostics
+
+### mcp_get_diagnostics
+
+Return extension diagnostic information as a JSON object.
+
+```sql
+mcp_get_diagnostics() → JSON
+```
+
+**Returns:** JSON object containing:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `log_level` | string | Active log level: `trace`, `debug`, `info`, `warn`, `error`, `off` |
+| `extension_version` | string | Loaded extension version (e.g. `2.1.0`) |
+| `logging_available` | boolean | Whether MCP logging is wired into DuckDB's logging facility |
+
+**Example:**
+
+```sql
+SELECT mcp_get_diagnostics();
+-- {"log_level":"info","extension_version":"2.1.0","logging_available":true}
+```
+
+Use this when filing bug reports — it captures the exact extension version and log level without requiring a separate `duckdb_extensions()` query.
+
+---
+
+## Prompt Templates
+
+Register reusable prompt templates that this DuckDB instance will serve over MCP. Registered templates appear in the `prompts/list` response and can be rendered via `prompts/get` by connected clients. They can also be rendered locally in SQL for preview or testing.
+
+Templates use `{variable}` placeholder syntax.
+
+!!! note "Local vs remote"
+    The functions below manage prompts that **this** DuckDB instance exposes as an MCP server. To retrieve prompts from a **remote** MCP server that DuckDB is attached to, use `mcp_list_prompts(server_name)` / `mcp_get_prompt(server_name, ...)` — see [Remote Prompt Functions](client.md#remote-prompt-functions) in the client reference.
+
+### mcp_register_prompt_template
+
+Register a new prompt template with the local server.
+
+```sql
+-- As PRAGMA (no output)
+PRAGMA mcp_register_prompt_template('name', 'description', 'template_content');
+
+-- As SELECT (returns status string)
+SELECT mcp_register_prompt_template('name', 'description', 'template_content');
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | VARCHAR | Unique template name (used by clients as the prompt name) |
+| `description` | VARCHAR | Human-readable description |
+| `template_content` | VARCHAR | Template body with `{variable}` placeholders |
+
+**Example:**
+
+```sql
+PRAGMA mcp_register_prompt_template(
+    'sql_query',
+    'Generate a SQL query',
+    'Write a SQL query to {action} from the {table} table where {condition}.'
+);
+```
+
+Once registered (and after the server starts), this template is discoverable by clients via `prompts/list` and retrievable via `prompts/get`.
+
+---
+
+### mcp_list_prompt_templates
+
+List all registered templates on the local server.
+
+```sql
+mcp_list_prompt_templates() → JSON
+```
+
+**Example:**
+
+```sql
+SELECT mcp_list_prompt_templates();
+```
+
+---
+
+### mcp_render_prompt_template
+
+Render a registered template with supplied arguments — useful for previewing prompts or driving them from SQL without going through the MCP protocol.
+
+```sql
+mcp_render_prompt_template(name, arguments_json) → VARCHAR
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | VARCHAR | Template name |
+| `arguments_json` | VARCHAR | JSON object mapping placeholder names to values |
+
+**Example:**
+
+```sql
+SELECT mcp_render_prompt_template(
+    'sql_query',
+    '{"action": "count users", "table": "users", "condition": "created_at > ''2024-01-01''"}'
+);
+-- Returns: "Write a SQL query to count users from the users table where created_at > '2024-01-01'."
+```
+
+---
+
 ## Built-in Server Tools
 
 When running as an MCP server, these tools are automatically available to clients:
@@ -413,7 +660,9 @@ Execute read-only SQL queries.
 | Argument | Type | Required | Description |
 |----------|------|----------|-------------|
 | `sql` | string | Yes | SQL SELECT statement |
-| `format` | string | No | Output format: `json` (default), `markdown`, `csv` |
+| `format` | string | No | Output format: `json` (default), `jsonl`, `csv`, `markdown`, `text` |
+
+The default can be changed server-wide via `default_result_format` (see [Configuration](configuration.md#output-options)).
 
 **Example request:**
 
@@ -469,18 +718,28 @@ Get comprehensive database information including schemas, tables, and extensions
 
 ### export
 
-Export query results to a file.
+Export query results inline or to a file.
 
 **Arguments:**
 
 | Argument | Type | Required | Description |
 |----------|------|----------|-------------|
-| `query` | string | Yes | SQL query to export |
-| `output` | string | No | Output file path |
-| `format` | string | No | Format: `json`, `csv`, `parquet` (parquet requires output path) |
+| `query` | string | Yes | Read-only SQL query to export |
+| `output` | string | No | Output file path — only available when `export_allow_file_output` is enabled |
+| `format` | string | No | Output format (see below) |
+
+**Supported formats:**
+
+| Mode | Formats |
+|------|---------|
+| Inline (no `output`) | `json`, `jsonl`, `csv`, `markdown`, `text` |
+| File export (with `output`) | `json`, `csv`, `parquet` |
+
+!!! note "File output is disabled by default"
+    `export_allow_file_output` defaults to `false` — inline return is the only mode available until you explicitly enable file output in the server config. The tool's advertised `inputSchema` reflects this: the `output` argument only appears when file output is allowed.
 
 !!! warning
-    When `output` is not specified, results are returned inline. Inline export only supports `json`, `csv`, and `markdown` formats. Use a file path for `parquet` exports.
+    The `export` tool only allows read-only statements. Use the `execute` tool for DDL/DML.
 
 ---
 
@@ -498,7 +757,7 @@ Execute DDL/DML statements (CREATE, INSERT, UPDATE, DELETE, etc.).
     The `execute` tool is **disabled by default** because it allows modifying the database. Only enable it when you trust the MCP clients connecting to your server.
 
     ```sql
-    SELECT mcp_server_start('stdio', 'localhost', 0, '{"enable_execute_tool": true}');
+    PRAGMA mcp_server_start('stdio', '{"enable_execute_tool": true}');
     ```
 
 ---
@@ -525,7 +784,7 @@ mcp_server_send_request(request_json) → VARCHAR (JSON)
 
 ```sql
 -- Start memory server
-SELECT mcp_server_start('memory', 'localhost', 0, '{}');
+PRAGMA mcp_server_start('memory');
 
 -- Send initialize request
 SELECT mcp_server_send_request('{
@@ -619,17 +878,17 @@ CORS is disabled by default. To enable CORS for browser-based clients, set the `
 
 ```sql
 -- Allow all origins
-SELECT mcp_server_start('http', 'localhost', 8080, '{"cors_origins": "*"}');
+PRAGMA mcp_server_start('http', 'localhost', 8080, '{"cors_origins": "*"}');
 
 -- Allow specific origins
-SELECT mcp_server_start('http', 'localhost', 8080, '{"cors_origins": "https://example.com, https://app.example.com"}');
+PRAGMA mcp_server_start('http', 'localhost', 8080, '{"cors_origins": "https://example.com, https://app.example.com"}');
 ```
 
 ### Example: Using curl
 
 ```bash
 # Start server
-duckdb -c "LOAD 'duckdb_mcp'; SELECT mcp_server_start('http', 'localhost', 8080, '{}');"
+duckdb -c "LOAD duckdb_mcp; SELECT mcp_server_start('http', 'localhost', 8080, '{}');"
 
 # Health check
 curl http://localhost:8080/health
@@ -672,7 +931,7 @@ curl -X POST http://localhost:8080/mcp \
 For production use, enable HTTPS with SSL certificates:
 
 ```sql
-SELECT mcp_server_start('https', '0.0.0.0', 8443, '{
+PRAGMA mcp_server_start('https', '0.0.0.0', 8443, '{
     "auth_token": "secure-token-here",
     "ssl_cert_path": "/etc/ssl/certs/server.crt",
     "ssl_key_path": "/etc/ssl/private/server.key"


### PR DESCRIPTION
## Summary

Audit and cleanup pass on user-facing docs after the v2.1 release. Fills in coverage for v2.1 features that only appeared in the changelog, fixes a handful of stale/broken references, and standardizes syntax across the guide examples.

### What changed

**v2.1 feature coverage (was missing entirely)**
- New **State Introspection** reference section in `docs/reference/server.md` covering `mcp_tools()`, `mcp_resources()`, `mcp_server_config()`, and the no-arg table form of `mcp_list_tools()` — schemas verified live against the compiled extension
- New **Diagnostics** section documenting `mcp_get_diagnostics()`
- New **Multi-Statement Tools** section in `docs/guides/custom-tools.md` covering `mcp_publish_execution_tool` with `SET VARIABLE` and temp-table staging examples and a bindings (object vs array form) explanation
- Cross-link from `docs/guides/server-usage.md` Monitoring section into the new state introspection reference
- `docs/examples.md` 05-custom-tools entry now shows both single-statement and multi-statement tool forms

**Prompt templates relocated**
- Confirmed via live `prompts/list` MCP request that `mcp_register_prompt_template` / `mcp_list_prompt_templates` / `mcp_render_prompt_template` are server-side — they're served by the local MCP server, not client-local state
- Moved from `docs/reference/client.md` to a new Prompt Templates section in `docs/reference/server.md`
- `docs/reference/client.md` prompt section renamed to **Remote Prompt Functions** with a cross-link back

**Critical fixes**
- Fixed wrong GitHub org in two high-traffic files (`github.com/teague` → `teaguesterling`) in `docs/index.md` and `docs/getting-started.md`
- `docs/getting-started.md` now leads with `INSTALL duckdb_mcp FROM community` instead of building from source; source build is shown as the fallback for development
- `docs/reference/server.md` query tool format list updated to actual supported formats (`json`/`jsonl`/`csv`/`markdown`/`text`), verified against `src/result_formatter.cpp`
- `docs/reference/server.md` export tool section rewritten with a two-mode format table (inline vs file export) and a note that `export_allow_file_output` defaults to false

**Consistency pass**
- Standardized `mcp_server_start` call syntax on `PRAGMA` short form across `index.md`, `examples.md`, `security.md`, `configuration.md`, and `server.md`. Legitimate SELECT-form references preserved (reference overview, config mode example, internal docs)
- Replaced legacy `LOAD 'duckdb_mcp'` with `LOAD duckdb_mcp` in user-facing docs
- Added a scalar-vs-table disambiguation note to `mcp_list_tools` in `reference/client.md`
- Fixed stale `'v1.3.2'` example string in `reference/server.md` `mcp_publish_resource` example

### Cross-reference validation

Grep-verified every new internal link resolves to a real `###` anchor:
- `server.md#state-introspection`, `server.md#mcp_list_tools`, `server.md#mcp_publish_execution_tool`, `server.md#prompt-templates`
- `custom-tools.md#multi-statement-tools`
- `client.md#remote-prompt-functions`

## Notes

- Pre-existing mismatch noted but **not** fixed in this PR: `src/include/duckdb_mcp_extension.hpp:10` has `DUCKDB_MCP_VERSION = "2.0.0"` while the git tag + community-extensions description.yml say `2.1.0`. This is a source-side drift, separate from docs cleanup — happy to fix in a follow-up if wanted.
- `mkdocs build --strict` couldn't be run in this environment (module not installed locally). Link validation was done manually via grep.

## Test plan

- [ ] `mkdocs build --strict` passes (if mkdocs is set up in CI)
- [ ] Spot-check the new State Introspection section in the rendered site
- [ ] Verify the `custom-tools.md#multi-statement-tools` anchor resolves in the live docs
- [ ] Confirm `docs/reference/client.md` → `server.md#prompt-templates` cross-link renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)