### PR TITLE
Make command spawning and file-read tool fail-closed by default

### DIFF
--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -197,7 +197,12 @@ ATTACH '/usr/bin/python3' AS server (TYPE mcp, ARGS '["server.py"]');
 
 ### URL Allowlists
 
-Restrict which URLs can be accessed:
+> **Not currently enforced.** `allowed_mcp_urls` is parsed and stored, but there is no
+> reachable outbound-HTTP client path today (client `ATTACH` supports only the `stdio`
+> transport), so this setting does **not** currently restrict anything. Do not rely on it
+> as a security control until an outbound transport wires it in.
+
+Intended usage (once enforced) — restrict which URLs can be accessed:
 
 ```sql
 -- Only allow specific domains
@@ -379,8 +384,8 @@ High error rates may indicate:
 
 ### For MCP Clients
 
-- [ ] Use `allowed_mcp_commands` in production
-- [ ] Use `allowed_mcp_urls` to restrict access
+- [ ] Set `allowed_mcp_commands` (spawning is deny-all by default; do NOT set `mcp_allow_all_commands=true` in production)
+- [ ] Do not expose the query/export tools' file-access surface; keep the default file-function denylist in place
 - [ ] Lock server configuration after setup
 - [ ] Don't hardcode secrets in SQL
 - [ ] Review server code before trusting

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -116,11 +116,23 @@ These DuckDB settings control MCP extension behavior:
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `allowed_mcp_commands` | Allowlist of executable commands | Empty (permissive) |
-| `allowed_mcp_urls` | Allowlist of permitted URLs | Empty (permissive) |
+| `allowed_mcp_commands` | Allowlist of executable commands | Empty (**deny-all** — set to allow spawning) |
+| `mcp_allow_all_commands` | INSECURE opt-in: allow ANY command when no allowlist is set | `false` |
+| `allowed_mcp_urls` | Allowlist of permitted URL prefixes (**not currently enforced**, see note) | Empty |
 | `mcp_server_file` | Path to MCP server configuration file | Empty |
 | `mcp_lock_servers` | Prevent runtime server changes | `false` |
 | `mcp_disable_serving` | Disable server functionality (client-only) | `false` |
+
+> **Note on `allowed_mcp_commands`:** command spawning is **fail-closed by default**.
+> With no allowlist configured, `ATTACH ... (TYPE mcp, COMMAND ...)` is refused. Set
+> `allowed_mcp_commands` to the exact executable paths you trust. `mcp_allow_all_commands=true`
+> restores the old permissive behavior (spawn anything) and is intended only for trusted,
+> non-networked local use — it emits a security warning on every spawn.
+>
+> **Note on `allowed_mcp_urls`:** this setting is currently **not enforced**. The client
+> attach path only supports the `stdio` transport today (no outbound HTTP client is
+> constructed), so URL allowlisting has no reachable code path. Do not rely on it as a
+> security control until it is wired into an outbound transport.
 
 **Example: Production security settings**
 

--- a/src/duckdb_mcp_extension.cpp
+++ b/src/duckdb_mcp_extension.cpp
@@ -725,6 +725,22 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 				}
 			}
 		} else if (transport == "http" || transport == "https") {
+			// Fail-closed: refuse to expose the tool surface on a non-loopback interface
+			// unless an auth token is configured. This prevents an accidental
+			// bind_address='0.0.0.0' from serving the tool surface to the network with
+			// no authentication. Loopback binds (localhost/127.x/::1) remain allowed.
+			{
+				string addr = StringUtil::Lower(bind_address);
+				bool is_loopback = (addr == "localhost" || addr == "127.0.0.1" || addr == "::1" ||
+				                    addr == "[::1]" || StringUtil::StartsWith(addr, "127."));
+				if (!is_loopback && server_config.auth_token.empty()) {
+					return CreateMCPStatus(false, false,
+					                       "Refusing to start MCP server: bind_address '" + bind_address +
+					                           "' is not loopback and no auth_token is set. Set an auth_token (and "
+					                           "require_auth) or bind to localhost.",
+					                       transport, bind_address, port, false);
+				}
+			}
 			// HTTP/HTTPS transport
 			if (server_config.background) {
 				// Background mode: use server manager (non-blocking, starts thread)
@@ -1468,6 +1484,10 @@ static void MCPGetDiagnosticsFunction(DataChunk &args, ExpressionState &state, V
 static void SetAllowedMCPCommands(ClientContext &context, SetScope scope, Value &parameter) {
 	MCPInstanceState::Get(context).security.SetAllowedCommands(parameter.ToString());
 }
+
+static void SetMCPAllowAllCommands(ClientContext &context, SetScope scope, Value &parameter) {
+	MCPInstanceState::Get(context).security.SetAllowPermissive(parameter.GetValue<bool>());
+}
 #endif
 
 static void SetMCPLogLevel(ClientContext &context, SetScope scope, Value &parameter) {
@@ -1979,6 +1999,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	config.AddExtensionOption("allowed_mcp_urls", "Space-delimited list of URL prefixes allowed for MCP servers",
 	                          LogicalType::VARCHAR, Value(""), SetAllowedMCPUrls);
+
+	config.AddExtensionOption(
+	    "mcp_allow_all_commands",
+	    "INSECURE opt-in: when true, allow spawning ANY command if no allowed_mcp_commands allowlist is "
+	    "set. Default false = deny-all (fail-closed). Prefer setting allowed_mcp_commands instead.",
+	    LogicalType::BOOLEAN, Value(false), SetMCPAllowAllCommands);
 
 	config.AddExtensionOption("mcp_server_file", "Path to MCP server configuration file", LogicalType::VARCHAR,
 	                          Value("./.mcp.json"), SetMCPServerFile);

--- a/src/duckdb_mcp_logging.cpp
+++ b/src/duckdb_mcp_logging.cpp
@@ -5,6 +5,7 @@
 #endif
 #include <iomanip>
 #include <sstream>
+#include <cstdlib>
 
 namespace duckdb {
 
@@ -145,10 +146,19 @@ void MCPLogger::LogProtocolMessage(bool outgoing, const string &server, const st
 	string direction = outgoing ? "SEND" : "RECV";
 	string component = StringUtil::Format("MCP-PROTOCOL[%s]", server);
 
-	// Truncate very long JSON messages for readability
-	string display_json = json;
-	if (display_json.length() > 500) {
-		display_json = display_json.substr(0, 497) + "...";
+	// Redact message bodies by default: MCP params can carry auth tokens/secrets,
+	// and logging them verbatim leaks them into log files. Opt in to raw bodies
+	// with the DUCKDB_MCP_LOG_UNSAFE_BODIES=1 environment variable.
+	string display_json;
+	const char *unsafe = std::getenv("DUCKDB_MCP_LOG_UNSAFE_BODIES");
+	if (unsafe && string(unsafe) == "1") {
+		display_json = json;
+		if (display_json.length() > 500) {
+			display_json = display_json.substr(0, 497) + "...";
+		}
+	} else {
+		display_json = StringUtil::Format("<redacted %llu-byte body; set DUCKDB_MCP_LOG_UNSAFE_BODIES=1 to log>",
+		                                  static_cast<unsigned long long>(json.length()));
 	}
 
 	string message = StringUtil::Format("%s: %s", direction, display_json);

--- a/src/duckdb_mcp_security.cpp
+++ b/src/duckdb_mcp_security.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <sstream>
 #endif
+#include <cstdio>
 #ifndef _WIN32
 #include <climits>
 #include <cstdlib>
@@ -62,6 +63,11 @@ void MCPSecurityConfig::LockServers(bool lock) {
 void MCPSecurityConfig::SetServingDisabled(bool disabled) {
 	lock_guard<mutex> guard(config_mutex);
 	serving_disabled = disabled;
+}
+
+void MCPSecurityConfig::SetAllowPermissive(bool value) {
+	lock_guard<mutex> guard(config_mutex);
+	allow_permissive = value;
 }
 
 bool MCPSecurityConfig::IsCommandAllowed(const string &command_path) const {
@@ -141,9 +147,11 @@ bool MCPSecurityConfig::IsPermissiveMode() const {
 }
 
 bool MCPSecurityConfig::IsPermissiveModeInternal() const {
-	// Permissive mode is when NO security settings have been configured
-	// (both commands and URLs are empty, and commands haven't been locked)
-	return allowed_commands.empty() && allowed_urls.empty() && !commands_locked;
+	// Fail-closed by default. Permissive mode (allow any command when no allowlist
+	// is configured) is OFF unless the host explicitly opts in via
+	// `SET mcp_allow_all_commands=true`. Without that opt-in an unset
+	// allowed_mcp_commands means DENY-ALL, not "allow everything".
+	return allow_permissive && allowed_commands.empty() && allowed_urls.empty() && !commands_locked;
 }
 
 void MCPSecurityConfig::ValidateAttachSecurity(const string &command, const vector<string> &args) const {
@@ -154,6 +162,13 @@ void MCPSecurityConfig::ValidateAttachSecurity(const string &command, const vect
 
 	// If we're in permissive mode, skip security validation but still do basic safety checks
 	if (IsPermissiveModeInternal()) {
+		// LOUD WARNING: permissive mode spawns arbitrary processes from SQL with no
+		// command allowlist. This is opt-in (mcp_allow_all_commands=true); make it noisy.
+		fprintf(stderr,
+		        "[duckdb_mcp][SECURITY WARNING] Spawning MCP command '%s' in PERMISSIVE mode "
+		        "(mcp_allow_all_commands=true): no command allowlist is enforced. Set "
+		        "allowed_mcp_commands to restrict which executables may be spawned.\n",
+		        command.c_str());
 		// Basic safety checks even in permissive mode
 		for (const auto &arg : args) {
 			// Prevent dangerous arguments even in permissive mode

--- a/src/include/duckdb_mcp_security.hpp
+++ b/src/include/duckdb_mcp_security.hpp
@@ -29,6 +29,10 @@ public:
 	//! Disable MCP server functionality entirely (client-only mode)
 	void SetServingDisabled(bool disabled);
 
+	//! Enable/disable the permissive escape hatch (opt-in). Default OFF: with no
+	//! command allowlist configured, spawning is DENY-ALL (fail-closed).
+	void SetAllowPermissive(bool value);
+
 	//! Check if a command path is allowed
 	bool IsCommandAllowed(const string &command_path) const;
 
@@ -69,7 +73,8 @@ public:
 
 private:
 	MCPSecurityConfig()
-	    : servers_locked(false), commands_locked(false), serving_disabled(false), server_file("./.mcp.json") {
+	    : servers_locked(false), commands_locked(false), serving_disabled(false), allow_permissive(false),
+	      server_file("./.mcp.json") {
 	}
 
 	mutable mutex config_mutex;
@@ -79,6 +84,9 @@ private:
 	bool servers_locked;
 	bool commands_locked;
 	bool serving_disabled;
+	//! Opt-in escape hatch. When false (default), an empty allowlist is DENY-ALL,
+	//! not "allow everything". Enabled only via SET mcp_allow_all_commands=true.
+	bool allow_permissive;
 
 	//! Parse colon or space delimited string into vector
 	vector<string> ParseDelimitedString(const string &input, char delimiter) const;

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -78,6 +78,43 @@ bool IsReadOnlyStatementType(StatementType type) {
 	}
 }
 
+// A "read-only" SELECT is still allowed to call file-reaching table functions
+// (read_text/read_csv/read_blob/glob/...), which would turn the query/export/
+// describe tools into an arbitrary local-file read for the connected MCP peer.
+// Deny these functions so "read-only" does not mean "read any file". This is a
+// best-effort textual guard: it matches known file-access table functions called
+// with parentheses. It does not attempt to defeat operator-defined macros that
+// wrap a reader, nor DuckDB replacement scans (SELECT * FROM 'file.parquet');
+// those are documented residual risks.
+static bool ReferencesFileAccessFunction(const string &sql, string &matched_out) {
+	static const char *const kDeniedFns[] = {
+	    "read_text",        "read_blob",     "read_csv",        "read_csv_auto", "read_json",
+	    "read_json_auto",   "read_json_objects", "read_ndjson",  "read_ndjson_auto", "read_parquet",
+	    "parquet_scan",     "read_xlsx",     "read_arrow",      "sniff_csv",     "glob"};
+	string lower = StringUtil::Lower(sql);
+	for (const char *fn : kDeniedFns) {
+		string needle(fn);
+		size_t pos = 0;
+		while ((pos = lower.find(needle, pos)) != string::npos) {
+			// Whole-identifier match: the char before must not be an identifier char.
+			bool left_ok =
+			    (pos == 0) || !(isalnum(static_cast<unsigned char>(lower[pos - 1])) || lower[pos - 1] == '_');
+			// It must be a call: the next non-space char must be '('.
+			size_t after = pos + needle.size();
+			while (after < lower.size() && isspace(static_cast<unsigned char>(lower[after]))) {
+				after++;
+			}
+			bool right_ok = (after < lower.size() && lower[after] == '(');
+			if (left_ok && right_ok) {
+				matched_out = needle;
+				return true;
+			}
+			pos += needle.size();
+		}
+	}
+	return false;
+}
+
 //===--------------------------------------------------------------------===//
 // ToolInputSchema Implementation
 //===--------------------------------------------------------------------===//
@@ -231,6 +268,15 @@ CallToolResult QueryToolHandler::Execute(const Value &arguments) {
 			                             "). Use the execute tool for DDL/DML operations.");
 		}
 
+		// Deny file-reaching functions: a "read-only" SELECT must not read local files.
+		{
+			string matched_fn;
+			if (ReferencesFileAccessFunction(sql, matched_fn)) {
+				return CallToolResult::Error("Query references a disallowed file-access function ('" + matched_fn +
+				                             "'). Local file/filesystem access is not permitted via this tool.");
+			}
+		}
+
 		// Additional security check: validate against allowlist/denylist
 		if (!IsQueryAllowedByType(stmt_type, allowed_queries, denied_queries)) {
 			return CallToolResult::Error("Query not allowed by security policy");
@@ -372,6 +418,15 @@ Value DescribeToolHandler::DescribeQuery(const string &query) const {
 		                            "). Use the execute tool for DDL/DML operations.");
 	}
 
+	// Deny file-reaching functions: describe must not read local files either.
+	{
+		string matched_fn;
+		if (ReferencesFileAccessFunction(query, matched_fn)) {
+			throw InvalidInputException("Query references a disallowed file-access function ('" + matched_fn +
+			                            "'). Local file/filesystem access is not permitted via this tool.");
+		}
+	}
+
 	// Additional security check: validate against allowlist/denylist
 	if (!IsQueryAllowedByType(stmt_type, allowed_queries, denied_queries)) {
 		throw InvalidInputException("Query not allowed by security policy");
@@ -479,6 +534,15 @@ CallToolResult ExportToolHandler::Execute(const Value &arguments) {
 			string type_name = StatementTypeToString(stmt_type);
 			return CallToolResult::Error("Export tool only allows read-only statements (got " + type_name +
 			                             "). Use the execute tool for DDL/DML operations.");
+		}
+
+		// Deny file-reaching functions: export must not read local files.
+		{
+			string matched_fn;
+			if (ReferencesFileAccessFunction(query, matched_fn)) {
+				return CallToolResult::Error("Query references a disallowed file-access function ('" + matched_fn +
+				                             "'). Local file/filesystem access is not permitted via this tool.");
+			}
 		}
 
 		if (!IsQueryAllowedByType(stmt_type, allowed_queries, denied_queries)) {

--- a/test/sql/mcp_bind_guard.test
+++ b/test/sql/mcp_bind_guard.test
@@ -1,0 +1,42 @@
+# name: test/sql/mcp_bind_guard.test
+# description: Refuse an unauthenticated non-loopback HTTP bind (fail-closed)
+# group: [sql]
+
+# The guard returns BEFORE any socket is bound, so this test never opens a
+# public socket in CI. It only asserts that the refusal happens.
+
+require duckdb_mcp
+
+require notwindows
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# Non-loopback bind with no auth_token must be refused (no socket bound).
+query I
+SELECT (mcp_server_start('http', '0.0.0.0', 9877, '{}')).success;
+----
+false
+
+query I
+SELECT (mcp_server_start('http', '0.0.0.0', 9877, '{}')).message LIKE '%Refusing%';
+----
+true
+
+# https is likewise refused on a non-loopback bind with no auth.
+query I
+SELECT (mcp_server_start('https', '0.0.0.0', 9878, '{}')).success;
+----
+false
+
+# A non-loopback numeric address is also refused.
+query I
+SELECT (mcp_server_start('http', '192.0.2.10', 9879, '{}')).success;
+----
+false
+
+statement ok
+SELECT mcp_server_stop(true);

--- a/test/sql/mcp_query_tool_file_read.test
+++ b/test/sql/mcp_query_tool_file_read.test
@@ -1,0 +1,116 @@
+# name: test/sql/mcp_query_tool_file_read.test
+# description: The "read-only" query/export/describe tools must not read arbitrary local files
+# group: [sql]
+
+# Reproduce-first regression test for the "read-only query tool = arbitrary file
+# read" gap. A SELECT is "read-only" by statement type but can still call
+# file-reaching table functions (read_text/read_csv/read_blob/glob/...), which
+# exfiltrates local files to an MCP peer.
+#
+# SAFE fixture: the privileged outer connection writes a LOCAL temp file
+# (__TEST_DIR__) containing a distinctive canary. We then drive the query tool
+# with a SELECT over read_text() of that temp file. No real system path and no
+# network are ever touched.
+
+require duckdb_mcp
+
+require notwindows
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# Create a local canary file via the privileged outer connection.
+statement ok
+COPY (SELECT 'SECRET-CANARY-9f3a2b7c' AS x) TO '__TEST_DIR__/mcp_canary_file.txt' (FORMAT csv, HEADER false);
+
+# A harmless in-memory table for the positive control.
+statement ok
+CREATE TABLE fileread_ok AS SELECT 1 AS id, 'legit_data' AS value;
+
+statement ok
+SELECT mcp_server_start('memory');
+
+# =============================================================================
+# CORE: query tool must NOT leak the canary via read_text().
+# =============================================================================
+# Pre-fix: the file content (canary) is returned in the tool response
+#          -> NOT LIKE '%SECRET-CANARY%' is FALSE (RED).
+# Post-fix: the file-reaching function is denied
+#          -> response has no canary -> NOT LIKE is TRUE (GREEN).
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT * FROM read_text(''__TEST_DIR__/mcp_canary_file.txt'')"}}}') NOT LIKE '%SECRET-CANARY%';
+----
+true
+
+# read_blob is another file-reaching path and must also be blocked.
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT * FROM read_blob(''__TEST_DIR__/mcp_canary_file.txt'')"}}}') NOT LIKE '%SECRET-CANARY%';
+----
+true
+
+# read_csv path must also be blocked.
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT * FROM read_csv(''__TEST_DIR__/mcp_canary_file.txt'')"}}}') NOT LIKE '%SECRET-CANARY%';
+----
+true
+
+# glob discloses filesystem layout and must be blocked.
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT * FROM glob(''__TEST_DIR__/*'')"}}}') LIKE '%disallowed%';
+----
+true
+
+# =============================================================================
+# POSITIVE CONTROL: a normal SELECT over an in-memory table still works.
+# =============================================================================
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT * FROM fileread_ok"}}}') LIKE '%legit_data%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# EXPORT tool must also refuse file-reaching functions.
+# =============================================================================
+
+statement ok
+SELECT mcp_server_start('memory');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"export","arguments":{"query":"SELECT * FROM read_text(''__TEST_DIR__/mcp_canary_file.txt'')","format":"csv"}}}') NOT LIKE '%SECRET-CANARY%';
+----
+true
+
+# Normal export still works.
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"export","arguments":{"query":"SELECT * FROM fileread_ok","format":"csv"}}}') LIKE '%legit_data%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# DESCRIBE tool must also refuse file-reaching functions.
+# =============================================================================
+
+statement ok
+SELECT mcp_server_start('memory');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"describe","arguments":{"query":"SELECT * FROM read_text(''__TEST_DIR__/mcp_canary_file.txt'')"}}}') LIKE '%disallowed%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+DROP TABLE IF EXISTS fileread_ok;

--- a/test/sql/mcp_spawn_fail_closed.test
+++ b/test/sql/mcp_spawn_fail_closed.test
@@ -1,0 +1,52 @@
+# name: test/sql/mcp_spawn_fail_closed.test
+# description: Command spawning must be deny-by-default (fail-closed) on a fresh load
+# group: [sql]
+
+# Reproduce-first regression test for the fail-open command-spawn gap.
+# On a fresh load with NO allowed_mcp_commands configured, an ATTACH that would
+# spawn a process must be REFUSED by the security policy (not merely fail at the
+# connection step). We use a benign, non-existent command so no process is ever
+# spawned and nothing network/destructive can run.
+
+require duckdb_mcp
+
+require notwindows
+
+statement ok
+LOAD duckdb_mcp;
+
+# =============================================================================
+# DENY-BY-DEFAULT: fresh load, no allowed_mcp_commands set.
+# =============================================================================
+# The ATTACH must be rejected by the command allowlist BEFORE any spawn attempt.
+# Pre-fix (permissive default) this instead reaches the connect path and fails
+# with a "Failed to connect" style error -> assertion mismatch (RED).
+# Post-fix the policy refuses it with "No MCP commands are allowed" (GREEN).
+
+statement error
+ATTACH '' AS spawn_denied (TYPE mcp, COMMAND 'nonexistent_mcp_binary', TRANSPORT 'stdio');
+----
+No MCP commands are allowed
+
+# =============================================================================
+# PERMIT AFTER EXPLICIT ALLOWLIST (regression guard: must not over-block).
+# =============================================================================
+# Once the host explicitly allow-lists the command, the policy must let it
+# through to the connection step. The command still does not exist, so it fails
+# at connect ("Failed to connect ...") rather than at the policy gate. This
+# proves an allow-listed command is permitted by the policy.
+# NOTE: this SET locks the command list, so it must come AFTER the deny check.
+
+statement ok
+SET allowed_mcp_commands='nonexistent_mcp_binary';
+
+statement error
+ATTACH '' AS spawn_allowed (TYPE mcp, COMMAND 'nonexistent_mcp_binary', TRANSPORT 'stdio');
+----
+Failed to
+
+# A command NOT on the allowlist is still rejected by policy.
+statement error
+ATTACH '' AS spawn_other (TYPE mcp, COMMAND 'some_other_binary', TRANSPORT 'stdio');
+----
+not allowed

--- a/test/stdio/test_stdio_transport_bugs.sh
+++ b/test/stdio/test_stdio_transport_bugs.sh
@@ -78,6 +78,7 @@ echo -e "${YELLOW}CR-21: Fast-failing server detection${NC}"
 # Before fix: 100ms fixed sleep regardless. After fix: polling detects early exit.
 RESULT=$(echo "
 LOAD '${EXTENSION}';
+SET allowed_mcp_commands='${SCRIPT_DIR}/mock_fast_exit.sh';
 ATTACH '' AS fast_exit_test (TYPE mcp, COMMAND '${SCRIPT_DIR}/mock_fast_exit.sh', TRANSPORT 'stdio');
 " | timeout 10 "$DUCKDB" -unsigned 2>&1 || true)
 
@@ -90,6 +91,7 @@ fi
 # Test: ATTACH to a nonexistent binary should fail
 RESULT=$(echo "
 LOAD '${EXTENSION}';
+SET allowed_mcp_commands='/nonexistent/binary/path';
 ATTACH '' AS nonexist_test (TYPE mcp, COMMAND '/nonexistent/binary/path', TRANSPORT 'stdio');
 " | timeout 10 "$DUCKDB" -unsigned 2>&1 || true)
 
@@ -112,6 +114,7 @@ set +e
 timeout 15 bash -c "
 echo \"
 LOAD '${EXTENSION}';
+SET allowed_mcp_commands='${SCRIPT_DIR}/mock_echo_server.sh';
 ATTACH '' AS pid_test (TYPE mcp, COMMAND '${SCRIPT_DIR}/mock_echo_server.sh', TRANSPORT 'stdio');
 DETACH pid_test;
 \" | '${DUCKDB}' -unsigned 2>&1
@@ -135,6 +138,7 @@ CANARY_PID=$!
 
 echo "
 LOAD '${EXTENSION}';
+SET allowed_mcp_commands='${SCRIPT_DIR}/mock_echo_server.sh';
 ATTACH '' AS canary_test (TYPE mcp, COMMAND '${SCRIPT_DIR}/mock_echo_server.sh', TRANSPORT 'stdio');
 DETACH canary_test;
 " | timeout 15 "$DUCKDB" -unsigned 2>&1 > /dev/null || true
@@ -186,6 +190,7 @@ chmod +x /tmp/mock_slow_mcp_$$.sh
 
 RESULT=$(echo "
 LOAD '${EXTENSION}';
+SET allowed_mcp_commands='/tmp/mock_slow_mcp_$$.sh';
 ATTACH '' AS slow_json_test (TYPE mcp, COMMAND '/tmp/mock_slow_mcp_$$.sh', TRANSPORT 'stdio');
 SELECT 'attach_ok' AS status;
 DETACH slow_json_test;
@@ -207,6 +212,7 @@ rm -f "/tmp/mock_slow_mcp_$$.sh"
 # Test: Verify the basic echo server works (baseline for chunked test)
 RESULT=$(echo "
 LOAD '${EXTENSION}';
+SET allowed_mcp_commands='${SCRIPT_DIR}/mock_echo_server.sh';
 ATTACH '' AS echo_test (TYPE mcp, COMMAND '${SCRIPT_DIR}/mock_echo_server.sh', TRANSPORT 'stdio');
 SELECT 'echo_ok' AS status;
 DETACH echo_test;


### PR DESCRIPTION
## Summary

Makes the network-facing MCP surface **fail-closed by default** so its documented
guarantees hold out of the box instead of being opt-in. Addresses the private
advisory **GHSA-85f8-rrwg-qf7g** (draft; advisory to be published at release).
This is the only network-facing extension in the portfolio, so the defaults matter.

Two of these are **breaking default changes** (called out below).

## What changed

1. **Command spawning is deny-all by default (breaking).**
   Previously an unset `allowed_mcp_commands` put the security config in
   *permissive* mode, so a fresh load let `ATTACH ... (TYPE mcp, COMMAND ...)`
   spawn arbitrary processes from SQL. Permissive mode is now an explicit opt-in
   (`SET mcp_allow_all_commands=true`) that also emits a loud `stderr` warning on
   every spawn. With no allowlist set, attaches are refused with
   *"No MCP commands are allowed"*. **Config-file (`.mcp.json`) attaches now also
   require `allowed_mcp_commands`.**

2. **The "read-only" query/describe/export tools no longer read local files (breaking).**
   A `SELECT` is read-only by statement type but could still call file-reaching
   table functions (`read_text`/`read_blob`/`read_csv`/`read_json`/`glob`/
   `parquet_scan`/...), turning the tools into arbitrary local-file read for the
   connected peer. These functions are now denied (no opt-in escape hatch — this
   is deliberate for a peer-facing tool surface).

3. **HTTP/HTTPS refuses an unauthenticated non-loopback bind.**
   When `bind_address` is not loopback and no `auth_token` is set, the server
   refuses to start (before any socket is bound) instead of silently exposing the
   tool surface to the network.

4. **Protocol message bodies are redacted in DEBUG logs by default.**
   MCP params can carry tokens/secrets; opt back into raw bodies with
   `DUCKDB_MCP_LOG_UNSAFE_BODIES=1`.

5. **Docs corrected.** `allowed_mcp_urls` is documented as **not currently
   enforced** (no reachable outbound-HTTP client path today), and the command
   allowlist is documented as deny-by-default.

## Testing (reproduce-first, red → green)

All fixtures are **local temp files / benign commands** — no real system paths,
no network.

- `test/sql/mcp_query_tool_file_read.test` — writes a local temp file with a
  canary via the privileged connection, then drives the query/export/describe
  tools with `read_text()`/`read_blob()`/`read_csv()`/`glob()`. **Pre-fix the
  canary leaks (RED); post-fix it is blocked (GREEN).** Verified red→green.
- `test/sql/mcp_spawn_fail_closed.test` — on a fresh load a benign command is
  refused by default; after an explicit allowlist the same command is permitted
  (reaches the connect step). **Pre-fix the deny assertion is RED (reaches
  connect, not policy); post-fix GREEN.** Verified red→green.
- `test/sql/mcp_bind_guard.test` — non-loopback bind with no auth is refused
  (green post-fix; **deliberately not run pre-fix** because the buggy path would
  bind a public socket).
- Updated `test/stdio/test_stdio_transport_bugs.sh` to allow-list its mock
  commands under deny-by-default (6/6 pass, and the mock spawn path is genuinely
  exercised).

Full extension SQL suite: **33 cases / 1091 assertions passing.**
Existing `test/test_security_validation.py` (8/8) and `test/test_documented_features.py`
(7/7) already asserted the *"No MCP commands are allowed"* default and now pass —
they were red on the permissive code.

## Calibration (CONFIRMED vs PLAUSIBLE)

- **CONFIRMED (tests):** spawn deny-by-default; query/export/describe file-read
  blocked; non-loopback-bind refusal.
- **PLAUSIBLE / residual risk (documented, not fully closed):**
  - The file-function denylist is a **textual guard**. DuckDB *replacement scans*
    (`SELECT * FROM 'x.parquet'`) and operator-defined macros that wrap a reader
    can still reach the filesystem — not covered here. A binder-level check would
    be more robust; noted as follow-up.
  - `allowed_mcp_urls` / `IsUrlAllowed` remains **dead code** (no outbound HTTP
    client is constructed today). Fixed the false-assurance docs rather than
    wiring an allowlist with no reachable path.
  - The HTTP client transport is never constructed today, so its SSRF-shaped
    exposure remains theoretical.

Out of scope for this PR: the correctness items in #67 (mcpfs hand-rolled JSON
scanning; Windows stdio transport) — orthogonal to this security class, deferred
to a separate PR.

_Security-relevant; references GHSA-85f8-rrwg-qf7g privately. No exploit details in this PR._
