### PR TITLE
fix(tools): bind only params the SQL template references

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,26 @@ All notable changes to the DuckDB MCP Extension.
 
 ---
 
+## v2.1.2
+
+### Fixed
+
+- `mcp_publish_tool`: a schema property the SQL template never references no longer
+  breaks every call to the tool. The prepared-statement path bound all declared
+  properties, so DuckDB rejected the excess with
+  `Invalid Input Error: Parameter argument/count mismatch, identifiers of the excess
+  parameters: <name>`. Parameters are now filtered to those the statement expects,
+  matching `mcp_publish_execution_tool`, which already did this. Regression since
+  v2.0.0, when prepared binding replaced string interpolation.
+
+### Documentation
+
+- Custom tools guide: document `$param` in table function arguments (positional and
+  named), and the `COALESCE($param, default)` idiom for optional parameters that feed
+  a table function argument.
+
+---
+
 ## v2.0.0
 
 ### Security (15 bugs fixed from security audit)

--- a/docs/guides/custom-tools.md
+++ b/docs/guides/custom-tools.md
@@ -55,6 +55,52 @@ PRAGMA mcp_publish_tool(
 !!! note "SQL String Escaping"
     In SQL strings, use `''` for literal single quotes. The `$param` values are safely substituted.
 
+### Table Function Arguments
+
+`$param` works in table function arguments too — both positional and named. Many
+extensions expose their functionality this way, and no special handling is needed:
+
+```sql
+-- Positional argument
+PRAGMA mcp_publish_tool(
+    'search_articles',
+    'Full-text search across an archive',
+    'SELECT title, snippet FROM zim_search(getenv(''ZIM_FILES''), $query)',
+    '{"query": {"type": "string", "description": "Search term"}}',
+    '["query"]'
+);
+
+-- Named argument
+PRAGMA mcp_publish_tool(
+    'search_articles_capped',
+    'Full-text search with a caller-supplied result cap',
+    'SELECT title FROM zim_search(getenv(''ZIM_FILES''), $query, max_results := $max_results)',
+    '{
+        "query": {"type": "string", "description": "Search term"},
+        "max_results": {"type": "integer", "description": "Maximum rows to return"}
+    }',
+    '["query", "max_results"]'
+);
+```
+
+A table function is bound from its argument *values*, so DuckDB re-binds the
+statement on every call — each invocation sees the argument it was given.
+
+!!! warning "Wrap optional parameters in COALESCE"
+    An omitted optional parameter binds as SQL `NULL`, and table functions
+    generally reject a NULL argument at bind time — sometimes with a confusing
+    error, since the failure comes from the function, not from this extension.
+    Give every optional parameter a default with `COALESCE`:
+
+    ```sql
+    'SELECT title FROM zim_search(getenv(''ZIM_FILES''), $query,
+                                  max_results := COALESCE($max_results, 25))'
+    ```
+
+    `COALESCE` is folded to a constant before the table function is bound, so the
+    function sees `25` when the caller omits the argument. Required parameters
+    need no such wrapper.
+
 ## Parameter Schema
 
 The parameter schema follows JSON Schema format:
@@ -124,6 +170,12 @@ For required parameters:
 ```sql
 '["customer_id", "start_date"]'  -- These must be provided
 ```
+
+A property the SQL template never references is ignored — only the parameters the
+statement actually uses are bound, so a schema stays valid while you edit the
+template. The reverse is an error: a `$token` in the template with no matching
+property fails the call with `Values were not provided for the following prepared
+statement parameters: <name>`.
 
 ## Output Format
 

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -740,7 +740,17 @@ CallToolResult SQLToolHandler::Execute(const Value &arguments) {
 		if (!prepared->HasError()) {
 			// Template is preparable — use parameterized execution
 			auto named_params = BuildNamedParameters(parser);
-			auto result = prepared->Execute(named_params);
+
+			// Filter to only params this statement expects: a schema may declare
+			// properties the template never references, and DuckDB rejects extras.
+			case_insensitive_map_t<BoundParameterData> filtered_params;
+			for (auto &entry : named_params) {
+				if (prepared->named_param_map.count(entry.first)) {
+					filtered_params[entry.first] = std::move(entry.second);
+				}
+			}
+
+			auto result = prepared->Execute(filtered_params);
 			if (result->HasError()) {
 				return CallToolResult::Error("SQL error: " + result->GetError());
 			}

--- a/test/sql/mcp_prepared_params.test
+++ b/test/sql/mcp_prepared_params.test
@@ -199,7 +199,167 @@ SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":50,"method":"tools/call","
 true
 
 # =============================================================================
-# PREP-07: Execute error propagation — bad value for typed param returns error
+# PREP-07: Table function arguments — $param in a positional argument
+#
+# Table functions are bound from their argument values, so a $param in an
+# argument position forces DuckDB to re-bind the statement on every execution.
+# This section pins that behaviour down: extensions commonly expose their
+# functionality as table functions (read_csv, glob, zim_search, ...).
+# =============================================================================
+
+query I
+SELECT mcp_publish_tool(
+    'range_rows',
+    'Rows from a table function whose argument is a parameter',
+    'SELECT ''row_'' || range AS tag FROM range($n)',
+    '{"n": {"type": "integer", "description": "Row count"}}',
+    '["n"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+# n=3 must reach range() → row_0 .. row_2
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":70,"method":"tools/call","params":{"name":"range_rows","arguments":{"n":3}}}') LIKE '%row_2%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":71,"method":"tools/call","params":{"name":"range_rows","arguments":{"n":3}}}') NOT LIKE '%row_3%';
+----
+true
+
+# A second call with a different value must re-bind, not reuse the first value
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":72,"method":"tools/call","params":{"name":"range_rows","arguments":{"n":5}}}') LIKE '%row_4%';
+----
+true
+
+# =============================================================================
+# PREP-08: Table function arguments — $param in a named argument position
+# =============================================================================
+
+statement ok
+COPY (SELECT * FROM (VALUES (1, 'alpha'), (2, 'beta')) t(id, label)) TO '__TEST_DIR__/prep_params.csv' (HEADER);
+
+query I
+SELECT mcp_publish_tool(
+    'csv_rows',
+    'Read a CSV with a parameterized named argument',
+    'SELECT * FROM read_csv(''__TEST_DIR__/prep_params.csv'', header := $hdr)',
+    '{"hdr": {"type": "boolean", "description": "Whether the file has a header row"}}',
+    '["hdr"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+# header := true → the header row names the columns
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":80,"method":"tools/call","params":{"name":"csv_rows","arguments":{"hdr":true}}}') LIKE '%alpha%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":81,"method":"tools/call","params":{"name":"csv_rows","arguments":{"hdr":true}}}') NOT LIKE '%column0%';
+----
+true
+
+# header := false → columns fall back to generated names, proving the value bound
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":82,"method":"tools/call","params":{"name":"csv_rows","arguments":{"hdr":false}}}') LIKE '%column0%';
+----
+true
+
+# =============================================================================
+# PREP-09: Schema properties not referenced by the SQL template
+#
+# A tool may declare a property the template does not use ($param removed while
+# iterating on the SQL, a placeholder for a future revision, ...). Binding every
+# declared property unconditionally makes DuckDB reject the call with
+# "Parameter argument/count mismatch". Only params the statement expects may be
+# bound.
+# =============================================================================
+
+query I
+SELECT mcp_publish_tool(
+    'excess_schema_param',
+    'Schema declares a property the SQL never references',
+    'SELECT * FROM prep_test WHERE name = $name',
+    '{"name": {"type": "string", "description": "Name to find"}, "note": {"type": "string", "description": "Not referenced by the SQL"}}',
+    '["name"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+# Caller supplies the unreferenced property
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":90,"method":"tools/call","params":{"name":"excess_schema_param","arguments":{"name":"alice","note":"ignored"}}}') LIKE '%alice%';
+----
+true
+
+# Caller omits it — it is still declared, so it must still be filtered out
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":91,"method":"tools/call","params":{"name":"excess_schema_param","arguments":{"name":"bob"}}}') LIKE '%bob%';
+----
+true
+
+# Same situation with a table function in play
+query I
+SELECT mcp_publish_tool(
+    'range_rows_excess',
+    'Table function tool with an unreferenced schema property',
+    'SELECT ''row_'' || range AS tag FROM range($n)',
+    '{"n": {"type": "integer", "description": "Row count"}, "max_results": {"type": "integer", "description": "Not referenced by the SQL"}}',
+    '["n"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":92,"method":"tools/call","params":{"name":"range_rows_excess","arguments":{"n":2,"max_results":10}}}') LIKE '%row_1%';
+----
+true
+
+# The interpolation fallback already tolerates unreferenced properties; the
+# prepared path must behave the same way.
+query I
+SELECT mcp_publish_tool(
+    'greet_tool_excess',
+    'Macro tool with an unreferenced schema property',
+    'SELECT greet($name) as greeting',
+    '{"name": {"type": "string", "description": "Name to greet"}, "note": {"type": "string", "description": "Not referenced by the SQL"}}',
+    '["name"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":93,"method":"tools/call","params":{"name":"greet_tool_excess","arguments":{"name":"world","note":"ignored"}}}') LIKE '%Hello, world%';
+----
+true
+
+# =============================================================================
+# PREP-10: Unknown $token in the template still reports a clear error
+# =============================================================================
+
+query I
+SELECT mcp_publish_tool(
+    'undeclared_token',
+    'Template references a token missing from the schema',
+    'SELECT * FROM prep_test WHERE name = $name AND id = $missing',
+    '{"name": {"type": "string", "description": "Name to find"}}',
+    '["name"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":95,"method":"tools/call","params":{"name":"undeclared_token","arguments":{"name":"alice"}}}') LIKE '%missing%';
+----
+true
+
+# =============================================================================
+# PREP-11: Execute error propagation — bad value for typed param returns error
 # =============================================================================
 
 query I


### PR DESCRIPTION
## Problem

A tool whose schema declares a property the SQL template never references fails on **every** call:

```
SQL error: Invalid Input Error: Parameter argument/count mismatch,
identifiers of the excess parameters: max_results
```

`SQLToolHandler::Execute` built bound values for all declared schema properties and passed them
straight to `PreparedStatement::Execute`. DuckDB rejects parameters the statement doesn't expect.

`ExecutionSQLToolHandler` already filtered against `prepared->named_param_map` (added in 4cdd2c4);
the single-statement handler never got the same fix. Regression since v2.0.0 (17be0b5), when
prepared binding replaced string interpolation — interpolation only substituted `$tokens` it
actually found in the template, so unreferenced properties were harmless.

## Fix

Filter the bound parameters to those in `prepared->named_param_map`, mirroring the execution-tool
handler. One site, `src/server/tool_handlers.cpp`.

## On the report that prompted this

This came in as *"`mcp_publish_tool` doesn't bind `$param` placeholders for table functions"*.
**That claim does not reproduce.** Verified against the reporter's exact template, extension build,
and transport (stdio via `duckdb -init`), plus the queued publish-before-start path:

| Case | Result |
|---|---|
| `zim_search(getenv('ZIM_FILES'), $query, …)` verbatim | binds correctly |
| Distinct values across calls | correct, different results each call |
| `max_results := $max` (named argument position) | works |
| `read_csv($path)` (return schema depends on the param) | works |

DuckDB re-binds a statement whose table function arguments contain parameters, so values do reach
the function. The reported template failed because its schema declared properties the SQL had
hardcoded — this bug, surfacing through an error that names neither the tool nor the schema.

## Tests

Added to `test/sql/mcp_prepared_params.test`, using only built-in table functions:

- **PREP-07** — `$param` in a positional table function argument; re-binds per call
- **PREP-08** — `$param` in a named argument (`read_csv(…, header := $hdr)`)
- **PREP-09** — unreferenced schema property, across plain / table function / macro templates *(the bug)*
- **PREP-10** — a `$token` with no matching property still reports a clear error

Watched PREP-09 fail before the fix (`test/sql/mcp_prepared_params.test:295`), pass after.
Full suite: **1109 assertions, 33 test cases, all passing.**

## Docs

- Custom tools guide gains a table-function section (positional + named `$param`), since the
  behaviour was undocumented and assumed broken.
- Documents `COALESCE($param, default)` for optional parameters feeding a table function argument —
  an omitted optional binds SQL `NULL`, which table functions generally reject at bind time.
  Verified that `COALESCE` folds to a constant before the function is bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PybK1Z3z6Huww57obvL7L