### PR TITLE
examples: add 12-zim-lookup (ZIM/Wikipedia article search)

### DIFF
--- a/examples/12-zim-lookup/README.md
+++ b/examples/12-zim-lookup/README.md
@@ -1,0 +1,140 @@
+# ZIM Article Lookup MCP Server
+
+A DuckDB MCP server for searching and reading articles from ZIM files (e.g., Wikipedia).
+
+## Overview
+
+This example demonstrates using DuckDB with the `zim` extension to create an MCP server that can:
+
+- **Search** articles by keyword with relevance scoring
+- **Retrieve** full article text (HTML → Markdown conversion)
+- **List** available articles in a ZIM file
+
+## Setup
+
+### Files
+
+- `init-mcp-server.sql` — DuckDB init script (loads extensions, starts MCP)
+- `mcp.json` — MCP client configuration
+- `README.md` — This file
+
+### Requirements
+
+- DuckDB ≥ 1.5.5 (with `zim` extension available)
+- A ZIM file (e.g., [Wikipedia Mini](https://download.kiwix.org/zim/wikipedia/en.wikipedia.org/wikipedia_en_mini_2024-01.zim))
+
+## Quick Start
+
+### As an MCP Server (for AI Assistants)
+
+```bash
+# Set the ZIM file path
+export ZIM_FILES=/path/to/wikipedia_en_mini.zim
+
+# Start the server (stdio transport, blocks until stdin closes)
+duckdb -init init-mcp-server.sql
+```
+
+Add to Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "zim-lookup": {
+      "command": "duckdb",
+      "args": ["-init", "/path/to/init-mcp-server.sql"],
+      "env": {
+        "ZIM_FILES": "/path/to/wikipedia_en_mini.zim"
+      }
+    }
+  }
+}
+```
+
+### Testing Directly
+
+```bash
+# Search articles
+ZIM_FILES=/path/to/file.zim duckdb -c "
+LOAD duckdb_mcp; LOAD zim; LOAD webbed; LOAD duck_block_utils; LOAD markdown;
+SELECT title, snippet FROM zim_search(getenv('ZIM_FILES'), 'quantum mechanics',
+  ignore_errors := true, with_snippet := true,
+  result_offset := CAST(0 AS BIGINT), max_results := CAST(10 AS BIGINT));
+" --ascii
+
+# Get full article as Markdown
+ZIM_FILES=/path/to/file.zim duckdb -c "
+LOAD duckdb_mcp; LOAD zim; LOAD webbed; LOAD duck_block_utils; LOAD markdown;
+SELECT duck_blocks_to_md(html_to_duck_blocks(zim_get_text(getenv('ZIM_FILES'), 'Protein')));
+" --markdown
+```
+
+## How It Works
+
+### Architecture
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌──────────────┐
+│  MCP Client  │────▶│  DuckDB MCP      │────▶│  ZIM File    │
+│  (Claude,    │     │  Server          │     │  (Wikipedia) │
+│   OpenCode)  │◀────│  (stdio)         │◀────│              │
+└─────────────┘     └──────────────────┘     └──────────────┘
+                        │
+                        ├── Built-in `query` tool (SQL with getenv())
+                        └── Extensions: zim, webbed, duck_block_utils, markdown
+```
+
+### Key Patterns
+
+1. **`getenv('ZIM_FILES')`** — The ZIM file path is passed via environment variable, not as a tool parameter. This avoids the `mcp_publish_tool` limitation with table function parameter binding.
+
+2. **Built-in `query` tool** — Rather than publishing custom tools (which don't support table function parameters), we use the built-in `query` tool with SQL templates that reference `getenv('ZIM_FILES')`.
+
+3. **HTML → Markdown pipeline** — ZIM article text is stored as HTML. The conversion chain is:
+   ```sql
+   duck_blocks_to_md(html_to_duck_blocks(zim_get_text(getenv('ZIM_FILES'), 'Article Name')))
+   ```
+
+## SQL Patterns
+
+### Search Articles
+
+```sql
+SELECT title, snippet, score
+FROM zim_search(getenv('ZIM_FILES'), 'search term',
+  ignore_errors := true,
+  with_snippet := true,
+  result_offset := CAST(0 AS BIGINT),
+  max_results := CAST(10 AS BIGINT));
+```
+
+### Get Full Article
+
+```sql
+SELECT duck_blocks_to_md(html_to_duck_blocks(
+    zim_get_text(getenv('ZIM_FILES'), 'Article Name')));
+```
+
+### Search with Article Content
+
+```sql
+SELECT title, snippet
+FROM zim_search(getenv('ZIM_FILES'), 'search term',
+  ignore_errors := true,
+  with_snippet := true,
+  result_offset := CAST(0 AS BIGINT),
+  max_results := CAST(10 AS BIGINT));
+```
+
+## Notes
+
+- **Parameter binding limitation**: `mcp_publish_tool` does not bind `$param` placeholders for table functions (see issue #71). Use the built-in `query` tool with hardcoded SQL patterns instead.
+- **Extension loading order**: Load `zim` before `webbed` and `duck_block_utils`.
+- **Markdown conversion**: Requires `LOAD markdown` in addition to `webbed` and `duck_block_utils`.
+- **Type casts**: `zim_search` requires `BIGINT` casts for `result_offset` and `max_results`.
+
+## Related
+
+- [duckdb_zim](https://github.com/duckdb/duckdb_zim) — ZIM file support for DuckDB
+- [MCP Specification](https://modelcontextprotocol.io/)
+- [DuckDB MCP Extension](https://github.com/duckdb/duckdb_mcp)

--- a/examples/12-zim-lookup/init-mcp-server.sql
+++ b/examples/12-zim-lookup/init-mcp-server.sql
@@ -1,0 +1,25 @@
+-- ZIM Article Lookup MCP Server - Initialization
+-- Searches and reads articles from ZIM files (e.g., Wikipedia)
+--
+-- Usage:
+--   ZIM_FILES=/path/to/file.zim duckdb -init init-mcp-server.sql
+--
+-- Note: Custom tools via mcp_publish_tool don't work with table functions
+-- (see github.com/teaguesterling/duckdb_mcp/issues/71). Use the built-in query tool
+-- with hardcoded SQL patterns referencing getenv('ZIM_FILES').
+
+-- Install (idempotent) + load. All five are community extensions.
+INSTALL duckdb_mcp FROM community;
+INSTALL zim FROM community;
+INSTALL webbed FROM community;
+INSTALL duck_block_utils FROM community;
+INSTALL markdown FROM community;
+
+LOAD duckdb_mcp;
+LOAD zim;
+LOAD webbed;
+LOAD duck_block_utils;
+LOAD markdown;
+
+-- Start MCP server (stdio transport, blocks until stdin closes)
+PRAGMA mcp_server_start('stdio');

--- a/examples/12-zim-lookup/mcp.json
+++ b/examples/12-zim-lookup/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "zim-lookup": {
+      "command": "duckdb",
+      "args": ["-init", "/path/to/examples/12-zim-lookup/init-mcp-server.sql"],
+      "env": {
+        "ZIM_FILES": "/path/to/wikipedia_en_mini.zim"
+      }
+    }
+  }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ This folder contains example configurations for running DuckDB as an MCP (Model 
 | [04-security](./04-security/) | Security features | Query restrictions, disabled tools |
 | [05-custom-tools](./05-custom-tools/) | Custom tools | DuckDB macros as domain tools |
 | [06-comprehensive](./06-comprehensive/) | Full featured | All features combined |
+| [12-zim-lookup](./12-zim-lookup/) | ZIM article search | Wikipedia lookup with `zim` extension |
 
 ## Quick Start
 


### PR DESCRIPTION
Adds `examples/12-zim-lookup` — a DuckDB MCP server that searches and reads
articles from ZIM files (e.g. Wikipedia) via the `zim` extension.

## What it does
- **Search** articles by keyword (`zim_search`, ranked, with snippets)
- **Retrieve** full article text as Markdown (`zim_get_text` → `html_to_duck_blocks` → `duck_blocks_to_md`)

## Design notes
- Uses the built-in **`query`** tool with `getenv('ZIM_FILES')` rather than custom
  published tools — table-function parameters don't bind through `mcp_publish_tool`
  (#71), so this is the working pattern.
- The init script **`INSTALL ... FROM community`** for all five extensions before
  `LOAD`, so it runs on a fresh machine — matching `09-docs` and the `07`–`10`
  examples.

## Verification
Tested end-to-end against a `wikipedia_en` mini ZIM on DuckDB v1.5.5:
- `zim_search(..., 'protein')` → 13 ranked hits
- full markdown pipeline renders `Protein` (~3.3 KB)

Files: `init-mcp-server.sql`, `mcp.json`, `README.md`, plus the index row in `examples/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)