### PR TITLE
fix(mcpfs): parse resources/read JSON properly; state the Windows client gap plainly (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,4 +190,4 @@ make test
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+Apache License 2.0 - see [LICENSE](LICENSE) and [NOTICE](NOTICE) for details.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ curl -X POST http://localhost:8080/mcp \
 
 ### As an MCP Client
 
+> **Windows:** MCP client connections are not available — attaching to a server
+> means spawning it over stdio, which is not implemented on Windows
+> ([#67](https://github.com/teaguesterling/duckdb_mcp/issues/67)). Use WSL.
+> Running DuckDB *as* an MCP server works on Windows.
+
 ```sql
 LOAD 'duckdb_mcp';
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,4 +135,4 @@ PRAGMA mcp_publish_tool(
 
 ## License
 
-MIT License - see [LICENSE](https://github.com/teaguesterling/duckdb_mcp/blob/main/LICENSE) for details.
+Apache License 2.0 - see [LICENSE](https://github.com/teaguesterling/duckdb_mcp/blob/main/LICENSE) and [NOTICE](https://github.com/teaguesterling/duckdb_mcp/blob/main/NOTICE) for details.

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -2,6 +2,14 @@
 
 These functions are used when DuckDB acts as an MCP client, connecting to external MCP servers.
 
+!!! warning "Platform support"
+    MCP **client** connections require spawning the server as a child process over
+    stdio, which is not implemented on Windows
+    ([#67](https://github.com/teaguesterling/duckdb_mcp/issues/67)); `stdio` is
+    currently the only client transport, so `ATTACH ... (TYPE mcp)` is unavailable
+    on Windows. Run DuckDB under WSL if you need to attach to an MCP server.
+    DuckDB-as-an-MCP-**server** (`mcp_server_start`) is unaffected.
+
 ## Connecting to MCP Servers
 
 ### ATTACH Statement

--- a/src/mcpfs/mcp_file_system.cpp
+++ b/src/mcpfs/mcp_file_system.cpp
@@ -6,8 +6,84 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/open_file_info.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/blob.hpp"
+#include "json_utils.hpp"
 
 namespace duckdb {
+
+namespace {
+
+//! Extract the file body from the JSON result of an MCP `resources/read` call.
+//!
+//! Per the MCP spec the result is `{"contents": [ ... ]}` where each entry is
+//! either a text content part (`"text"`) or a binary one (`"blob"`, base64).
+//! Every part is concatenated in order, newline-separated when a part does not
+//! already end in one, so line-oriented payloads (csv/jsonl) survive chunking.
+//!
+//! Returns false if the payload is not a recognisable `resources/read` result;
+//! the caller then falls back to exposing the raw JSON, as before.
+bool ExtractResourceContents(const string &json_result, string &out) {
+	yyjson_doc *doc = yyjson_read(json_result.c_str(), json_result.length(), 0);
+	if (!doc) {
+		return false;
+	}
+	DocGuard guard {doc};
+
+	yyjson_val *root = yyjson_doc_get_root(doc);
+	if (!root || !yyjson_is_obj(root)) {
+		return false;
+	}
+
+	yyjson_val *contents = yyjson_obj_get(root, "contents");
+	if (!contents || !yyjson_is_arr(contents)) {
+		return false;
+	}
+
+	string result;
+	bool found_any = false;
+
+	yyjson_arr_iter iter;
+	yyjson_arr_iter_init(contents, &iter);
+	yyjson_val *item;
+	while ((item = yyjson_arr_iter_next(&iter))) {
+		if (!yyjson_is_obj(item)) {
+			continue;
+		}
+
+		string part;
+		yyjson_val *text_val = yyjson_obj_get(item, "text");
+		if (text_val && yyjson_is_str(text_val)) {
+			part = string(yyjson_get_str(text_val), yyjson_get_len(text_val));
+		} else {
+			yyjson_val *blob_val = yyjson_obj_get(item, "blob");
+			if (!blob_val || !yyjson_is_str(blob_val)) {
+				continue;
+			}
+			string encoded(yyjson_get_str(blob_val), yyjson_get_len(blob_val));
+			try {
+				part = Blob::FromBase64(string_t(encoded));
+			} catch (const std::exception &) {
+				// Malformed base64: not a payload we can meaningfully decode.
+				return false;
+			}
+		}
+
+		if (found_any && !result.empty() && result.back() != '\n') {
+			result += '\n';
+		}
+		result += part;
+		found_any = true;
+	}
+
+	if (!found_any) {
+		return false;
+	}
+
+	out = std::move(result);
+	return true;
+}
+
+} // namespace
 
 // MCPFileHandle implementation
 
@@ -33,72 +109,14 @@ void MCPFileHandle::LoadResourceContent() {
 	try {
 		auto resource = connection->ReadResource(parsed_path.resource_uri);
 
-		// Extract the actual text content from the MCP JSON response
-		string json_response = resource.content;
+		// Extract the file body from the MCP `resources/read` result. If the
+		// payload is not a recognisable result, expose the raw JSON unchanged
+		// so callers still see *something* rather than an empty file.
 		string extracted_content;
-
-		// Look for pattern: "text":"..."
-		auto text_pos = json_response.find("\"text\":\"");
-		if (text_pos != string::npos) {
-			text_pos += 8; // len("\"text\":\"")
-			auto text_end = text_pos;
-
-			// Find the end of the text field, handling escaped quotes
-			bool escaped = false;
-			for (size_t i = text_pos; i < json_response.length(); i++) {
-				char c = json_response[i];
-				if (escaped) {
-					escaped = false;
-					continue;
-				}
-				if (c == '\\') {
-					escaped = true;
-					continue;
-				}
-				if (c == '"') {
-					text_end = i;
-					break;
-				}
-			}
-
-			if (text_end > text_pos) {
-				string escaped_text = json_response.substr(text_pos, text_end - text_pos);
-
-				// Unescape the content (handle \n, \t, \\, \")
-				for (size_t i = 0; i < escaped_text.length(); i++) {
-					if (escaped_text[i] == '\\' && i + 1 < escaped_text.length()) {
-						char next = escaped_text[i + 1];
-						if (next == 'n') {
-							extracted_content += '\n';
-							i++; // Skip the next character
-						} else if (next == 't') {
-							extracted_content += '\t';
-							i++; // Skip the next character
-						} else if (next == 'r') {
-							extracted_content += '\r';
-							i++; // Skip the next character
-						} else if (next == '\\') {
-							extracted_content += '\\';
-							i++; // Skip the next character
-						} else if (next == '"') {
-							extracted_content += '"';
-							i++; // Skip the next character
-						} else {
-							extracted_content += escaped_text[i];
-						}
-					} else {
-						extracted_content += escaped_text[i];
-					}
-				}
-
-				resource_content = extracted_content;
-			} else {
-				// Fallback: use the entire JSON response
-				resource_content = json_response;
-			}
+		if (ExtractResourceContents(resource.content, extracted_content)) {
+			resource_content = std::move(extracted_content);
 		} else {
-			// Fallback: use the entire JSON response
-			resource_content = json_response;
+			resource_content = resource.content;
 		}
 
 		content_loaded = true;

--- a/src/protocol/mcp_transport.cpp
+++ b/src/protocol/mcp_transport.cpp
@@ -17,6 +17,23 @@
 
 namespace duckdb {
 
+#ifdef _WIN32
+namespace {
+
+//! Single source of truth for the "no MCP client on Windows" diagnostic.
+//! Kept deliberately concrete: the previous "not supported on Windows yet"
+//! left users guessing whether the extension, the transport, or their command
+//! was at fault, and offered no way forward. See issue #67.
+const char *WindowsStdioUnsupportedMessage() {
+	return "MCP client connections are not available on Windows: stdio is the only client transport and "
+	       "spawning a child MCP server process is not implemented (see "
+	       "https://github.com/teaguesterling/duckdb_mcp/issues/67). Run DuckDB under WSL to attach to an "
+	       "MCP server. Server mode (mcp_server_start) is unaffected and works on Windows.";
+}
+
+} // namespace
+#endif
+
 StdioTransport::StdioTransport(const StdioConfig &config)
     : config(config), connected(false), process_pid(-1), process_reaped(false), stdin_fd(-1), stdout_fd(-1),
       stderr_fd(-1) {
@@ -150,8 +167,11 @@ string StdioTransport::GetConnectionInfo() const {
 
 bool StdioTransport::StartProcess() {
 #ifdef _WIN32
-	// Windows process creation not implemented yet
-	throw NotImplementedException("Stdio transport not supported on Windows yet");
+	// Windows child-process creation is not implemented. Doing it properly needs
+	// CreateProcess + named pipes with overlapped I/O (anonymous pipes cannot be
+	// polled with a timeout), a Job Object so orphaned servers die with DuckDB,
+	// and Windows-specific argv quoting -- see issue #67.
+	throw NotImplementedException(WindowsStdioUnsupportedMessage());
 #else
 	int stdin_pipe[2], stdout_pipe[2], stderr_pipe[2];
 
@@ -349,7 +369,8 @@ bool StdioTransport::StartProcess() {
 
 void StdioTransport::StopProcess() {
 #ifdef _WIN32
-	// Windows process termination not implemented yet
+	// Unreachable: StartProcess() throws on Windows, so there is never a child
+	// process to stop. See issue #67.
 #else
 	int pid = process_pid.load();
 	if (pid > 0) {
@@ -392,7 +413,7 @@ void StdioTransport::StopProcess() {
 
 bool StdioTransport::IsProcessRunning() const {
 #ifdef _WIN32
-	return false; // Windows process checking not implemented yet
+	return false; // Unreachable: no child process is ever started on Windows (issue #67)
 #else
 	int pid = process_pid.load();
 	if (pid <= 0 || process_reaped.load()) {
@@ -419,7 +440,7 @@ bool StdioTransport::IsProcessRunning() const {
 
 void StdioTransport::WriteToProcess(const string &data) {
 #ifdef _WIN32
-	throw NotImplementedException("Stdio transport not supported on Windows yet");
+	throw NotImplementedException(WindowsStdioUnsupportedMessage());
 #else
 	if (stdin_fd < 0) {
 		throw IOException("Process stdin not available");
@@ -443,7 +464,7 @@ void StdioTransport::WriteToProcess(const string &data) {
 
 string StdioTransport::ReadFromProcess() {
 #ifdef _WIN32
-	throw NotImplementedException("Stdio transport not supported on Windows yet");
+	throw NotImplementedException(WindowsStdioUnsupportedMessage());
 #else
 	if (stdout_fd < 0) {
 		throw IOException("Process stdout not available");
@@ -498,7 +519,7 @@ string StdioTransport::ReadFromProcess() {
 
 bool StdioTransport::WaitForData(int timeout_ms) {
 #ifdef _WIN32
-	return false; // Windows polling not implemented yet
+	return false; // Unreachable: no child process is ever started on Windows (issue #67)
 #else
 	struct pollfd pfd;
 	pfd.fd = stdout_fd;

--- a/test/mcpfs/mock_resource_server.sh
+++ b/test/mcpfs/mock_resource_server.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Mock MCP server used by test/sql/mcpfs_resource_content.test (issue #67).
+#
+# Speaks just enough JSON-RPC 2.0 over stdio to answer `initialize`,
+# `resources/list` and `resources/read`. Every resource URI returns a
+# deliberately shaped `resources/read` payload that exercises one JSON edge
+# case the old hand-rolled `"text":"` string scan got wrong.
+#
+# Responses are emitted with printf so backslash escapes are passed through
+# verbatim -- the payloads below are literal JSON.
+
+respond() {
+    # $1 = id, $2 = result JSON
+    printf '{"jsonrpc":"2.0","id":%s,"result":%s}\n' "$1" "$2"
+}
+
+INIT_RESULT='{"protocolVersion":"2024-11-05","capabilities":{"resources":{}},"serverInfo":{"name":"mcpfs-mock","version":"1.0"}}'
+
+LIST_RESULT='{"resources":[{"uri":"case://plain","name":"plain","mimeType":"text/plain"},{"uri":"case://spaced","name":"spaced","mimeType":"text/plain"},{"uri":"case://unicode","name":"unicode","mimeType":"text/plain"},{"uri":"case://decoy","name":"decoy","mimeType":"text/plain"},{"uri":"case://escapes","name":"escapes","mimeType":"text/plain"},{"uri":"case://multi","name":"multi","mimeType":"text/plain"},{"uri":"case://blob","name":"blob","mimeType":"application/octet-stream"}]}'
+
+read_result() {
+    case "$1" in
+    # Baseline: compact, single text part. Worked before and must keep working.
+    "case://plain")
+        printf '%s' '{"contents":[{"uri":"case://plain","mimeType":"text/plain","text":"PLAIN-OK"}]}'
+        ;;
+    # Whitespace after the colons (what json.dumps produces by default).
+    # The old scan looked for the literal `"text":"` and found nothing, so it
+    # handed back the entire JSON-RPC result as the file body.
+    "case://spaced")
+        printf '%s' '{"contents": [{"uri": "case://spaced", "mimeType": "text/plain", "text": "SPACED-OK"}]}'
+        ;;
+    # \uXXXX escapes: the old unescaper only knew \n \t \r \\ \" and passed
+    # the \u00e9 escape through literally.
+    "case://unicode")
+        printf '%s' '{"contents":[{"uri":"case://unicode","mimeType":"text/plain","text":"caf\u00e9-OK"}]}'
+        ;;
+    # A `text` key that is NOT the content field appears earlier in the
+    # payload. The old scan took the first `"text":"` it saw and returned the
+    # decoy.
+    "case://decoy")
+        printf '%s' '{"contents":[{"annotations":{"text":"DECOY"},"uri":"case://decoy","mimeType":"text/plain","text":"REAL-OK"}]}'
+        ;;
+    # Escapes the old unescaper mangled: \/ was emitted as a literal backslash
+    # followed by a slash.
+    "case://escapes")
+        printf '%s' '{"contents":[{"uri":"case://escapes","mimeType":"text/plain","text":"a\/b\"q\"\\z"}]}'
+        ;;
+    # Multiple content parts: the old scan stopped after the first one.
+    "case://multi")
+        printf '%s' '{"contents":[{"uri":"case://multi","mimeType":"text/plain","text":"PART-ONE"},{"uri":"case://multi#2","mimeType":"text/plain","text":"PART-TWO"}]}'
+        ;;
+    # Binary content part (base64). The old scan found no "text" at all and
+    # returned the raw JSON. "QkxPQi1PSw==" is "BLOB-OK".
+    "case://blob")
+        printf '%s' '{"contents":[{"uri":"case://blob","mimeType":"application/octet-stream","blob":"QkxPQi1PSw=="}]}'
+        ;;
+    *)
+        printf '%s' ''
+        ;;
+    esac
+}
+
+while IFS= read -r line; do
+    method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+    id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+
+    # Notifications carry no id and must not be answered.
+    if [ -z "$id" ]; then
+        continue
+    fi
+
+    case "$method" in
+    initialize)
+        respond "$id" "$INIT_RESULT"
+        ;;
+    ping)
+        respond "$id" '{}'
+        ;;
+    resources/list)
+        respond "$id" "$LIST_RESULT"
+        ;;
+    resources/read)
+        uri=$(printf '%s' "$line" | sed -n 's/.*"uri":"\([^"]*\)".*/\1/p')
+        result=$(read_result "$uri")
+        if [ -z "$result" ]; then
+            printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32002,"message":"Resource not found: %s"}}\n' "$id" "$uri"
+        else
+            respond "$id" "$result"
+        fi
+        ;;
+    *)
+        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":"Method not found"}}\n' "$id"
+        ;;
+    esac
+done

--- a/test/sql/mcpfs_resource_content.test
+++ b/test/sql/mcpfs_resource_content.test
@@ -1,0 +1,107 @@
+# name: test/sql/mcpfs_resource_content.test
+# description: mcpfs must extract resource content by parsing JSON, not by scanning for "text":"
+# group: [sql]
+
+# Reproduce-first regression test for issue #67 (finding 1):
+# MCPFileHandle::LoadResourceContent() used to locate the resource body by
+# searching the resources/read result for the literal `"text":"` and then
+# hand-unescaping the bytes up to the next unescaped quote. That is wrong for
+# any payload where a *different* `text` key appears first, for responses with
+# more than one content part, and for binary (`blob`) content parts.
+#
+# The fixture is a local mock MCP server (test/mcpfs/mock_resource_server.sh)
+# spawned over stdio. It touches no network and returns fixed payloads.
+
+require duckdb_mcp
+
+require notwindows
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+SET allowed_mcp_commands='/bin/sh';
+
+statement ok
+ATTACH '' AS mockfs (TYPE mcp, COMMAND '/bin/sh', ARGS '["test/mcpfs/mock_resource_server.sh"]', TRANSPORT 'stdio');
+
+# =============================================================================
+# Baseline: a compact, single-text-part response (worked before, must keep working)
+# =============================================================================
+
+query I
+SELECT content FROM read_text('mcp://mockfs/case://plain');
+----
+PLAIN-OK
+
+# =============================================================================
+# CORE 1: a decoy `text` key earlier in the payload.
+# =============================================================================
+# `contents[0].annotations.text` precedes the real `contents[0].text`.
+# Pre-fix the scan returned the first match -> 'DECOY' (RED).
+# Post-fix the JSON parser walks contents[].text -> 'REAL-OK' (GREEN).
+
+query I
+SELECT content FROM read_text('mcp://mockfs/case://decoy');
+----
+REAL-OK
+
+# =============================================================================
+# CORE 2: multi-part content.
+# =============================================================================
+# Pre-fix only the first part was returned -> 'PART-ONE' (RED).
+# Post-fix every text part is concatenated, newline-separated (GREEN).
+
+query I
+SELECT replace(content, chr(10), '|') FROM read_text('mcp://mockfs/case://multi');
+----
+PART-ONE|PART-TWO
+
+# =============================================================================
+# CORE 3: a binary (base64 `blob`) content part.
+# =============================================================================
+# Pre-fix there was no `"text":"` to find, so the whole JSON-RPC result was
+# handed back as the file body (RED). Post-fix the base64 is decoded (GREEN).
+
+query I
+SELECT content FROM read_text('mcp://mockfs/case://blob');
+----
+BLOB-OK
+
+# =============================================================================
+# Escaping / formatting guards.
+# =============================================================================
+# These already passed before the fix (the transport re-serialises the JSON-RPC
+# result with yyjson, which normalises whitespace and \uXXXX escapes) but they
+# pin the behaviour so the new parser cannot regress it.
+
+query I
+SELECT content FROM read_text('mcp://mockfs/case://spaced');
+----
+SPACED-OK
+
+query I
+SELECT content FROM read_text('mcp://mockfs/case://unicode');
+----
+café-OK
+
+query I
+SELECT content FROM read_text('mcp://mockfs/case://escapes');
+----
+a/b"q"\z
+
+# =============================================================================
+# Unknown resources yield no rows rather than JSON error noise as content.
+# =============================================================================
+# NOTE: MCPFileSystem::Glob() swallows the lookup failure and returns an empty
+# match list, so a missing resource reads as zero rows rather than raising.
+# That is pre-existing behaviour and out of scope here; what this pins down is
+# that the resources/read *error* payload never leaks out as file content.
+
+query I
+SELECT count(*) FROM read_text('mcp://mockfs/case://missing');
+----
+0
+
+statement ok
+DETACH mockfs;


### PR DESCRIPTION
Addresses both correctness findings in #67.

## 1. mcpfs resource-content extraction (fixed)

`MCPFileHandle::LoadResourceContent()` found the resource body by searching the
`resources/read` result for the literal `"text":"` and hand-unescaping up to the
next unescaped quote. Confirmed still present on `main` and confirmed broken for
three realistic payload shapes:

| payload | old result | correct |
|---|---|---|
| a different `text` key earlier in the payload (`contents[0].annotations.text`) | `DECOY` | `REAL-OK` |
| two content parts | `PART-ONE` (second part dropped) | `PART-ONE\nPART-TWO` |
| binary part (`blob`, base64) | the entire JSON-RPC result as the file body | `BLOB-OK` |

Replaced with a yyjson parse — the parser this extension already uses everywhere
else, including `MCPConnection::ListResources` a few files over. It walks
`contents[]`, concatenates every text part (newline-separating parts that do not
already end in one, so chunked csv/jsonl survives), and base64-decodes `blob`
parts. If the payload is not a recognisable `resources/read` result the raw JSON
is still exposed, exactly as before.

Two things the issue lists that turned out **not** to be reachable in practice,
and why: whitespace variants (`"text": "..."`) and `\uXXXX`/`\/` escapes are
normalised away before mcpfs ever sees them, because `MCPMessage::Parse` already
re-serialises the JSON-RPC `result` with `yyjson_val_write`. They are pinned by
tests anyway so the new parser cannot regress them.

### Test

`test/sql/mcpfs_resource_content.test` drives a local mock MCP server
(`test/mcpfs/mock_resource_server.sh`) over stdio — no network, fixed payloads —
and reads each case through `read_text('mcp://...')`. Written first and confirmed
RED on the old implementation:

```
Mismatch on row 1, column content(index 1)
DECOY <> REAL-OK
```

Green after the fix. Full suite: 1121 assertions in 34 test cases (was 1109/33).
`require notwindows`, since it spawns a child process.

## 2. Windows stdio transport (assessed, not implemented — message + docs only)

Still real. Judged too large to do blind, and untestable from Linux: a real
implementation needs `CreateProcess` with inherited pipe handles, **named** pipes
with overlapped I/O (anonymous pipes cannot be polled with a timeout, so the
`poll()` in `WaitForData` has no direct equivalent), a Job Object so orphaned
servers die with DuckDB, `TerminateProcess`/`GetExitCodeProcess` in place of
SIGTERM/waitpid, and Windows argv quoting — which is security-relevant here given
the command allowlist and sanitised-env work already in this repo. That is a
project, not a patch, and none of it can be exercised in this environment.

What this PR does instead: the exception said "Stdio transport not supported on
Windows yet", which leaves a user unsure whether the extension, the transport, or
their command is at fault. Since `stdio` is the *only* client transport
(`mcp_storage_extension.cpp` rejects anything else), the honest statement is that
`ATTACH ... (TYPE mcp)` does not work on Windows at all, while server mode does.
The message now says that, points at WSL, and links #67; README and
`docs/reference/client.md` say the same. The `StartProcess` stub now records what
a real implementation needs. No behaviour change on any platform.

## CI note

`main` is currently red, and was before this branch: the only failing jobs on the
last few `main` runs are the **advisory** "Canary — build against DuckDB main" leg
(expected-red forward-compat canary tracking DuckDB `main` API drift). Every
stable build leg and the integration tests pass. The canary only runs on push to
`main`/`workflow_dispatch`, so it does not run on this PR.

Refs #67