### PR TITLE
feat(server): add builtin_tools flag to suppress the built-in tool set (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,24 @@ SELECT mcp_call_tool('server', 'analyze', '{"dataset": "sales"}');
 | `export` | Export query results to files |
 | `execute` | Run DDL/DML statements (disabled by default) |
 
+Each is individually switchable in the server config, and `builtin_tools` turns
+the whole set off at once — for a server that should publish only its own
+curated tools:
+
+```sql
+-- Publish only what mcp_publish_tool registered; no query/export/describe/...
+PRAGMA mcp_server_start('stdio', 'localhost', 0, '{"builtin_tools": false}');
+
+-- Or keep just one of them
+PRAGMA mcp_server_start('stdio', 'localhost', 0,
+    '{"builtin_tools": false, "enable_query_tool": true}');
+```
+
+An explicit `enable_<tool>_tool` always wins over `builtin_tools`, whichever
+order they appear in. `builtin_tools: true` means the *default* set, so it never
+switches on `execute`. See
+[configuration reference](https://duckdb-mcp.readthedocs.io/reference/configuration/#tool-enabledisable-options).
+
 ## Publishing Custom Tools
 
 ```sql

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -96,11 +96,24 @@ PRAGMA mcp_publish_tool(
     '[]'
 );
 
--- Start the server with the general query tool disabled
-PRAGMA mcp_server_start('stdio', '{
-    "enable_query_tool": false
+-- Start the server with every built-in tool suppressed, so `get_public_stats`
+-- is the entire published surface.
+PRAGMA mcp_server_start('stdio', 'localhost', 0, '{
+    "builtin_tools": false
 }');
 ```
+
+!!! warning "Disable the whole set, not just `query`"
+    Turning off `enable_query_tool` alone still leaves `export` — which also
+    takes an arbitrary SQL `query` argument — and `describe`, `list_tables` and
+    `database_info`, which disclose schema. `builtin_tools: false` closes all of
+    them in one key. If you do want to keep one, name it explicitly; the
+    specific flag overrides the blanket one:
+
+    ```sql
+    PRAGMA mcp_server_start('stdio', 'localhost', 0,
+        '{"builtin_tools": false, "enable_describe_tool": true}');
+    ```
 
 ### Validate and Sanitize Inputs
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,12 +20,44 @@ Control which tools are exposed to MCP clients:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
+| `builtin_tools` | boolean | `true` | Blanket switch for the whole built-in set (see below) |
 | `enable_query_tool` | boolean | `true` | Enable SQL SELECT queries |
 | `enable_describe_tool` | boolean | `true` | Enable schema description |
 | `enable_list_tables_tool` | boolean | `true` | Enable table listing |
 | `enable_database_info_tool` | boolean | `true` | Enable database info |
 | `enable_export_tool` | boolean | `true` | Enable data export |
 | `enable_execute_tool` | boolean | `false` | Enable DDL/DML execution |
+
+#### Publishing only your own tools
+
+A server that publishes a curated tool with `mcp_publish_tool()` usually does not
+want to also hand clients arbitrary SQL through `query`. `builtin_tools: false`
+turns the entire built-in set off in one key:
+
+```sql
+PRAGMA mcp_publish_tool('semantic_query', '...', '...', '...', '...', 'markdown');
+PRAGMA mcp_server_start('stdio', 'localhost', 0, '{"builtin_tools": false}');
+```
+
+`tools/list` then returns only `semantic_query`, and `tools/call` on a built-in
+name is refused with *Tool not found*.
+
+**Precedence.** `builtin_tools` sets the baseline; an explicitly written
+`enable_<tool>_tool` always overrides it. So "everything off except `query`" is:
+
+```sql
+PRAGMA mcp_server_start('stdio', 'localhost', 0,
+    '{"builtin_tools": false, "enable_query_tool": true}');
+```
+
+The two keys may appear in either order — JSON object key order does not affect
+the result.
+
+!!! note "`builtin_tools: true` means the *default* set"
+    It restores `query`, `describe`, `list_tables`, `database_info` and `export`
+    — but **not** `execute`, which runs DDL/DML and stays opt-in. Enabling
+    `execute` always takes an explicit `enable_execute_tool: true`, so a
+    convenience flag can never switch it on by accident.
 
 ### Execute Tool Granular Control
 

--- a/src/duckdb_mcp_extension.cpp
+++ b/src/duckdb_mcp_extension.cpp
@@ -547,6 +547,31 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 				// Parse max_requests
 				server_config.max_requests = static_cast<uint32_t>(JSONUtils::GetInt(root, "max_requests", 0));
 
+				// Blanket built-in tool switch (issue #75). This is an alias over the
+				// individual enable_*_tool flags below, for the common "publish a
+				// curated tool and nothing else" case.
+				//
+				//   false -> every built-in tool off
+				//   true  -> the DEFAULT built-in set, which deliberately does NOT
+				//            include `execute`: it runs DDL/DML and stays opt-in, so
+				//            a convenience flag must never switch it on.
+				//
+				// Applied BEFORE the individual flags so that an explicitly written
+				// enable_*_tool key always wins over the blanket one, regardless of
+				// where the two sit in the JSON object. Order-independence matters:
+				// JSON object key order is not meaningful and must not change config.
+				yyjson_val *builtin_tools_val = yyjson_obj_get(root, "builtin_tools");
+				if (builtin_tools_val && yyjson_is_bool(builtin_tools_val)) {
+					const bool builtin_tools = yyjson_get_bool(builtin_tools_val);
+					server_config.enable_query_tool = builtin_tools;
+					server_config.enable_describe_tool = builtin_tools;
+					server_config.enable_export_tool = builtin_tools;
+					server_config.enable_list_tables_tool = builtin_tools;
+					server_config.enable_database_info_tool = builtin_tools;
+					// Not `builtin_tools`: `execute` is not part of the default set.
+					server_config.enable_execute_tool = false;
+				}
+
 				// Parse tool enable/disable flags
 				yyjson_val *val = yyjson_obj_get(root, "enable_query_tool");
 				if (val && yyjson_is_bool(val)) {

--- a/test/sql/mcp_builtin_tools_flag.test
+++ b/test/sql/mcp_builtin_tools_flag.test
@@ -1,0 +1,295 @@
+# name: test/sql/mcp_builtin_tools_flag.test
+# description: builtin_tools flag suppresses the built-in tool set; explicit per-tool flags override it
+# group: [sql]
+
+# Reproduce-first test for issue #75. A server that publishes a curated tool
+# still advertised `query`/`export`/etc., and the reporter could not find the
+# per-tool `enable_*_tool` keys (they are real, but were documented only in
+# configuration.md and security.md). `builtin_tools` is a blanket alias over
+# those flags.
+#
+# Semantics under test:
+#   builtin_tools:false -> every built-in tool off
+#   builtin_tools:true  -> the DEFAULT built-in set, which does NOT include
+#                          `execute` (opt-in for safety)
+#   an explicit enable_*_tool key ALWAYS overrides the blanket flag, whichever
+#                          order the two appear in the JSON object
+#
+# Assertions look for `"name":"<tool>"` in tools/list rather than a bare
+# substring, so a description mentioning a tool cannot make a test pass.
+
+require duckdb_mcp
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+CREATE TABLE never_meant_to_expose AS SELECT 1 AS id, 'secret' AS v;
+
+# =============================================================================
+# Baseline: with no flag, the default built-in set is advertised.
+# =============================================================================
+
+# NOTE: publications are queued and drained when the server starts, so the
+# curated tool is re-published before each start rather than once up front.
+
+statement ok
+SELECT mcp_publish_tool(
+    'curated_tool',
+    'The only tool this server means to publish',
+    'SELECT 42 AS answer',
+    '{}',
+    '[]',
+    'markdown'
+);
+
+statement ok
+SELECT mcp_server_start('memory');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}') LIKE '%"name":"query"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}') LIKE '%"name":"curated_tool"%';
+----
+true
+
+# `execute` is opt-in and must not be present by default.
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}') NOT LIKE '%"name":"execute"%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# CORE 1: builtin_tools:false leaves only the published tool.
+# =============================================================================
+# Pre-fix the key is ignored, so `query` is still advertised (RED).
+
+statement ok
+SELECT mcp_publish_tool(
+    'curated_tool',
+    'The only tool this server means to publish',
+    'SELECT 42 AS answer',
+    '{}',
+    '[]',
+    'markdown'
+);
+
+statement ok
+SELECT mcp_server_start('memory', 'localhost', 0, '{"builtin_tools": false}');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":10,"method":"tools/list","params":{}}') NOT LIKE '%"name":"query"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":11,"method":"tools/list","params":{}}') NOT LIKE '%"name":"export"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":12,"method":"tools/list","params":{}}') NOT LIKE '%"name":"describe"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":13,"method":"tools/list","params":{}}') NOT LIKE '%"name":"list_tables"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":14,"method":"tools/list","params":{}}') NOT LIKE '%"name":"database_info"%';
+----
+true
+
+# The curated tool survives -- this is a suppression of built-ins, not of everything.
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":15,"method":"tools/list","params":{}}') LIKE '%"name":"curated_tool"%';
+----
+true
+
+# A client that skips tools/list and calls `query` directly is refused too.
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":16,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT * FROM never_meant_to_expose"}}}') LIKE '%Tool not found%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":17,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT * FROM never_meant_to_expose"}}}') NOT LIKE '%secret%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# CORE 2: an explicit enable_*_tool key overrides the blanket flag.
+# =============================================================================
+# "everything off except query" must not silently ignore the enable_query_tool
+# the user wrote. This is the combination a user hits and the one a naive
+# implementation gets wrong in silence.
+
+statement ok
+SELECT mcp_publish_tool(
+    'curated_tool',
+    'The only tool this server means to publish',
+    'SELECT 42 AS answer',
+    '{}',
+    '[]',
+    'markdown'
+);
+
+statement ok
+SELECT mcp_server_start('memory', 'localhost', 0, '{"builtin_tools": false, "enable_query_tool": true}');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":20,"method":"tools/list","params":{}}') LIKE '%"name":"query"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":21,"method":"tools/list","params":{}}') NOT LIKE '%"name":"export"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":22,"method":"tools/list","params":{}}') NOT LIKE '%"name":"database_info"%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# CORE 3: precedence is independent of JSON key order.
+# =============================================================================
+# Same two keys, reversed. A blanket flag applied *after* the specific one
+# would clobber it and this would differ from CORE 2.
+
+statement ok
+SELECT mcp_publish_tool(
+    'curated_tool',
+    'The only tool this server means to publish',
+    'SELECT 42 AS answer',
+    '{}',
+    '[]',
+    'markdown'
+);
+
+statement ok
+SELECT mcp_server_start('memory', 'localhost', 0, '{"enable_query_tool": true, "builtin_tools": false}');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":30,"method":"tools/list","params":{}}') LIKE '%"name":"query"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":31,"method":"tools/list","params":{}}') NOT LIKE '%"name":"export"%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# CORE 4: builtin_tools:true restores the DEFAULT set, and never enables execute.
+# =============================================================================
+# `execute` runs DDL/DML and is deliberately opt-in. A blanket "true" must not
+# turn it on -- that would be a security regression hiding behind a convenience
+# flag.
+
+statement ok
+SELECT mcp_publish_tool(
+    'curated_tool',
+    'The only tool this server means to publish',
+    'SELECT 42 AS answer',
+    '{}',
+    '[]',
+    'markdown'
+);
+
+statement ok
+SELECT mcp_server_start('memory', 'localhost', 0, '{"builtin_tools": true}');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":40,"method":"tools/list","params":{}}') LIKE '%"name":"query"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":41,"method":"tools/list","params":{}}') NOT LIKE '%"name":"execute"%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# CORE 5: an explicit enable_execute_tool still wins over builtin_tools:false.
+# =============================================================================
+# Same precedence rule, applied to the opt-in tool: the blanket flag sets the
+# baseline, the specific key decides.
+
+statement ok
+SELECT mcp_publish_tool(
+    'curated_tool',
+    'The only tool this server means to publish',
+    'SELECT 42 AS answer',
+    '{}',
+    '[]',
+    'markdown'
+);
+
+statement ok
+SELECT mcp_server_start('memory', 'localhost', 0, '{"builtin_tools": false, "enable_execute_tool": true}');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":50,"method":"tools/list","params":{}}') LIKE '%"name":"execute"%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":51,"method":"tools/list","params":{}}') NOT LIKE '%"name":"query"%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+# =============================================================================
+# Non-boolean values are ignored, matching every other flag in this config.
+# =============================================================================
+
+statement ok
+SELECT mcp_publish_tool(
+    'curated_tool',
+    'The only tool this server means to publish',
+    'SELECT 42 AS answer',
+    '{}',
+    '[]',
+    'markdown'
+);
+
+statement ok
+SELECT mcp_server_start('memory', 'localhost', 0, '{"builtin_tools": "false"}');
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":60,"method":"tools/list","params":{}}') LIKE '%"name":"query"%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+DROP TABLE IF EXISTS never_meant_to_expose;


### PR DESCRIPTION
Closes #75 (external report from @venkata-chikkam).

## What was actually wrong

The reporter published a curated tool and found `tools/list` still advertising
`query`, `export`, `describe`, `list_tables` and `database_info`, so a client
could skip the curated tool and run arbitrary SQL over the whole database.

The per-tool `enable_*_tool` flags could already express the policy they wanted —
I verified the exact invocation works on `main`, in both the function and PRAGMA
forms, and in both the 2-arg and 4-arg config shapes. But they guessed four
plausible key names (`enable_default_tools`, `disable_default_tools`, `tools`,
`require_published`) and found none, because the flags are documented in
`configuration.md` and `security.md` but **not** in the README's "Built-in Server
Tools" table — which is where you look. That omission is the real defect, and it
gets fixed here alongside the alias they asked for.

## The alias

`builtin_tools` is a blanket switch over the existing flags — their option 3:

```sql
PRAGMA mcp_publish_tool('semantic_query', ...);
PRAGMA mcp_server_start('stdio', 'localhost', 0, '{"builtin_tools": false}');
-- tools/list -> [semantic_query];  tools/call query -> "Tool not found: query"
```

**Semantics, settled and documented:**

| config | result |
|---|---|
| `{"builtin_tools": false}` | every built-in off |
| `{"builtin_tools": true}` | the **default** set — `query`, `describe`, `list_tables`, `database_info`, `export`. Never `execute`. |
| `{"builtin_tools": false, "enable_query_tool": true}` | only `query` among the builtins |

Two rules worth stating explicitly, because both are the kind of thing an
implementation gets wrong silently:

1. **The specific flag beats the blanket one.** `builtin_tools` is applied
   *before* the individual `enable_*_tool` keys, so an explicitly written flag
   always wins. And since both are read by key rather than in document order, the
   result does not depend on where the two sit in the JSON object — tested in
   both orders.
2. **`builtin_tools: true` never enables `execute`.** `execute` runs DDL/DML and
   is deliberately opt-in; a convenience flag that switched it on would be a
   security regression hiding behind an ergonomics feature. Turning it on still
   takes an explicit `enable_execute_tool: true` — which, per rule 1, also works
   alongside `builtin_tools: false`.

## Docs

- **README** — the "Built-in Server Tools" table now shows how to switch them
  off. This is the discoverability root cause.
- **`docs/reference/configuration.md`** — `builtin_tools` in the options table,
  plus the precedence rule and the `execute` carve-out.
- **`docs/guides/security.md`** — the "create custom read-only tools" recipe
  disabled `enable_query_tool` alone, which still left `export` (itself taking an
  arbitrary SQL argument) plus three schema-disclosing tools. Now uses
  `builtin_tools: false`.

## Test

`test/sql/mcp_builtin_tools_flag.test`, written first and confirmed RED against
`main`:

```
SELECT ... 'tools/list' ... NOT LIKE '%"name":"query"%';
0 <> true
```

It asserts `tools/list` **contents** — matching `"name":"<tool>"` rather than a
bare substring, so a description mentioning a tool name cannot make it pass — and
would fail if the alias ever stopped suppressing the builtins. Covers:
suppression of all five, the curated tool surviving, a direct `tools/call` being
refused (not just absent from the listing), the override case in both key orders,
the `execute` carve-out in both directions, and non-boolean values being ignored.

Suite: 1155 assertions / 34 cases, green. Implementation is 25 lines in
`MCPServerStartCore`.