### PR TITLE
compat: build and pass tests against DuckDB v2.0 as well as the pinned v1.5

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -8,7 +8,24 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' && github.sha || '' }}
+  # Two things this key gets wrong if you write the obvious version, both of
+  # which manufacture phantom red checks rather than real failures.
+  #
+  # 1. github.event_name is part of the key ON PURPOSE. Without it, a push to a
+  #    branch and a workflow_dispatch on that same branch collide: same ref,
+  #    same sha, both with empty head_ref/base_ref, so they hash to one group.
+  #    cancel-in-progress then kills the push run every single time the canary
+  #    is dispatched by hand -- and `gh pr checks` renders a CANCELLED job as
+  #    `fail`, so the PR dashboard shows a wall of failures that never happened.
+  #
+  # 2. github.sha is deliberately NOT in the key. Including it for non-main refs
+  #    (which is what this workflow used to do) gives every commit on a branch
+  #    its own group, so cancel-in-progress can never supersede anything: rapid
+  #    pushes pile up instead of replacing each other, and stale runs from
+  #    superseded commits go on competing for the same runner quota as the
+  #    current one. Leaving it out is what makes a new push cancel its own
+  #    predecessor, which is the behaviour cancel-in-progress is for.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/src/catalog/mcp_catalog.cpp
+++ b/src/catalog/mcp_catalog.cpp
@@ -1,5 +1,6 @@
 #include "catalog/mcp_catalog.hpp"
 #include "catalog/mcp_schema_entry.hpp"
+#include "duckdb_compat.hpp"
 #include "protocol/mcp_connection.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
@@ -35,7 +36,9 @@ void MCPCatalog::Initialize(bool load_builtin) {
 void MCPCatalog::CreateDefaultSchema() {
 	// Create the default "main" schema
 	CreateSchemaInfo schema_info;
-	schema_info.schema = "main";
+	// v2.0 folded CreateInfo's catalog/schema/name into a private QualifiedName;
+	// the schema being created lives in its Schema() slot. See duckdb_compat.hpp.
+	CompatSetSchemaName(schema_info, "main");
 	schema_info.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
 
 	auto schema_entry = make_uniq<MCPSchemaEntry>(*this, schema_info, mcp_connection);
@@ -45,18 +48,19 @@ void MCPCatalog::CreateDefaultSchema() {
 optional_ptr<CatalogEntry> MCPCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
 	lock_guard<mutex> lock(catalog_lock);
 
-	if (schemas.find(info.schema) != schemas.end()) {
+	auto schema_name = CompatSchemaName(info);
+	if (schemas.find(schema_name) != schemas.end()) {
 		if (info.on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
-			throw CatalogException("Schema \"%s\" already exists", info.schema);
+			throw CatalogException("Schema \"%s\" already exists", schema_name);
 		}
 		// Schema already exists, return existing entry
-		return schemas[info.schema].get();
+		return schemas[schema_name].get();
 	}
 
 	// Create new schema
 	auto schema_entry = make_uniq<MCPSchemaEntry>(*this, info, mcp_connection);
 	auto result = schema_entry.get();
-	schemas[info.schema] = std::move(schema_entry);
+	schemas[schema_name] = std::move(schema_entry);
 	return result;
 }
 
@@ -88,16 +92,17 @@ void MCPCatalog::ScanSchemas(ClientContext &context, std::function<void(SchemaCa
 void MCPCatalog::DropSchema(ClientContext &context, DropInfo &info) {
 	lock_guard<mutex> lock(catalog_lock);
 
-	auto it = schemas.find(info.name);
+	auto drop_name = CompatEntryName(info);
+	auto it = schemas.find(drop_name);
 	if (it == schemas.end()) {
 		if (info.if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-			throw CatalogException("Schema \"%s\" not found", info.name);
+			throw CatalogException("Schema \"%s\" not found", drop_name);
 		}
 		return;
 	}
 
 	// Don't allow dropping the main schema
-	if (info.name == "main") {
+	if (drop_name == "main") {
 		throw CatalogException("Cannot drop the main schema");
 	}
 
@@ -114,7 +119,7 @@ SchemaCatalogEntry &MCPCatalog::GetOrCreateSchema(const string &name) {
 
 	// Create new schema
 	CreateSchemaInfo schema_info;
-	schema_info.schema = name;
+	CompatSetSchemaName(schema_info, name);
 	schema_info.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
 
 	auto schema_entry = make_uniq<MCPSchemaEntry>(*this, schema_info, mcp_connection);

--- a/src/catalog/mcp_schema_entry.cpp
+++ b/src/catalog/mcp_schema_entry.cpp
@@ -1,4 +1,5 @@
 #include "catalog/mcp_schema_entry.hpp"
+#include "duckdb_compat.hpp"
 #include "protocol/mcp_connection.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
@@ -87,10 +88,12 @@ optional_ptr<CatalogEntry> MCPSchemaEntry::LookupEntry(CatalogTransaction transa
 void MCPSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 	lock_guard<mutex> lock(schema_lock);
 
-	auto it = entries.find(info.name);
+	// v2.0 removed DropInfo::name in favour of a private QualifiedName; see duckdb_compat.hpp.
+	auto drop_name = CompatEntryName(info);
+	auto it = entries.find(drop_name);
 	if (it == entries.end()) {
 		if (info.if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-			throw CatalogException("Entry \"%s\" not found", info.name);
+			throw CatalogException("Entry \"%s\" not found", drop_name);
 		}
 		return;
 	}

--- a/src/client/mcp_storage_extension.cpp
+++ b/src/client/mcp_storage_extension.cpp
@@ -1,4 +1,5 @@
 #include "client/mcp_storage_extension.hpp"
+#include "duckdb_compat.hpp"
 #include "mcp_instance_state.hpp"
 #include "protocol/mcp_connection.hpp"
 #include "protocol/mcp_transport.hpp"
@@ -91,7 +92,9 @@ shared_ptr<MCPConnection> MCPStorageExtension::CreateMCPConnection(DatabaseInsta
 	auto transport = make_uniq<StdioTransport>(transport_config);
 
 	// Create connection (registration happens in RegisterMCPConnection)
-	auto connection = make_shared_ptr<MCPConnection>(info.name, std::move(transport));
+	// AttachInfo::name is an Identifier on v2.0; reading it back out as a string
+	// is deliberate (MCPConnection stores the ATTACH alias verbatim).
+	auto connection = make_shared_ptr<MCPConnection>(CompatNameStr(info.name), std::move(transport));
 	return connection;
 }
 

--- a/src/duckdb_mcp_extension.cpp
+++ b/src/duckdb_mcp_extension.cpp
@@ -2000,6 +2000,82 @@ static void PragmaMCPConfigEnd(ClientContext &context, const FunctionParameters 
 	MCPInstanceState::Get(db).config.config_mode = false;
 }
 
+//===--------------------------------------------------------------------===//
+// Scalar registration gate (DuckDB v2.0 change class 13)
+//===--------------------------------------------------------------------===//
+//
+// DuckDB v2.0 requires a scalar function that lets an EXECUTION error escape to
+// declare itself fallible. One that does not gets its error rewritten:
+//
+//   INTERNAL Error: Scalar function "f" threw an execution error, but the
+//   function is not marked as fallible - the function must call SetFallible().
+//
+// There is no compile signal and nothing in the API to grep for, so the only
+// protection is that the decision gets made deliberately, once per function.
+// That is what this gate is for: every ScalarFunction in this extension is
+// registered through RegisterScalar, and RegisterScalar cannot be called without
+// stating a verdict, so a new scalar function cannot be added without walking
+// past the audit below.
+//
+// WHAT COUNTS AS AN "EXECUTION ERROR" IS NARROWER THAN IT SOUNDS, and being
+// wrong about that in the conservative direction is what produced this file's
+// previous blanket marking of all 32. Enforcement runs through
+// Exception::IsExecutionError (duckdb/src/common/exception.cpp), which returns
+// true for exactly three types:
+//
+//     ExceptionType::INVALID_INPUT     (InvalidInputException)
+//     ExceptionType::OUT_OF_RANGE      (OutOfRangeException)
+//     ExceptionType::CONVERSION        (ConversionException)
+//
+// Everything else -- BinderException, IOException, InternalException,
+// OutOfMemoryException, std::bad_alloc -- makes ThrowNonFallibleFunctionError
+// take its `throw;` branch (duckdb/src/function/scalar_function.cpp:8-16) and
+// propagate UNCHANGED. Those types do not require SetFallible, and marking for
+// them is pure pessimisation: FunctionErrors is optimizer-visible on the pinned
+// v1.5 too (it feeds Expression::CanThrow(), which gates conjunct reordering,
+// filter pushdown and dictionary-expression caching), so an untrue CAN_THROW
+// makes the shipped planner needlessly conservative around that function.
+//
+// AUDIT RESULT FOR THIS EXTENSION: all 32 scalar functions are SWALLOWS_ALL, and
+// that is a property of how they are written rather than an accident. Each one
+// wraps its DuckDB-calling and MCP-calling work in `catch (const std::exception
+// &e)` and converts the failure into a value in the result vector ("ERROR: ...",
+// or a JSON-RPC error object) instead of throwing. That is deliberate -- see the
+// "return the error message instead of NULL" comments on the handlers -- and
+// test/sql/mcp_scalar_error_contract.test pins it so the property cannot be
+// dropped silently.
+//
+// The only exceptions that can escape one of these bodies come from the hoisted
+// preamble, and none of the three execution types is among them:
+//
+//   ExpressionState::GetContext()                    -> BinderException
+//   Vector::GetValue on an unimplemented vector type -> InternalException
+//   allocation inside a catch handler                -> OutOfMemoryException
+//
+// The GetValue<int32_t>() / GetValue<bool>() reads in mcp_server_start and
+// mcp_server_stop are the only value CONVERSIONS sitting outside a try, and they
+// are identity casts today because those arguments are registered as exactly
+// INTEGER and BOOLEAN. Widening either declared type would make them genuinely
+// fallible -- precisely the sort of change this gate exists to stop sliding past
+// unnoticed.
+enum class ScalarErrors : uint8_t {
+	//! Audited: no INVALID_INPUT / OUT_OF_RANGE / CONVERSION exception can leave
+	//! this function's body -- it converts failures into result values instead.
+	SWALLOWS_ALL,
+	//! An execution-class exception can escape. Must be declared, or v2.0
+	//! rewrites it as an InternalException naming SetFallible().
+	CAN_THROW
+};
+
+//! Register a scalar function, having stated whether it can raise an execution
+//! error. Use this rather than loader.RegisterFunction for every ScalarFunction.
+static void RegisterScalar(ExtensionLoader &loader, ScalarFunction function, ScalarErrors errors) {
+	if (errors == ScalarErrors::CAN_THROW) {
+		CompatSetFallible(function);
+	}
+	loader.RegisterFunction(function);
+}
+
 static void LoadInternal(ExtensionLoader &loader) {
 	auto &db = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(db);
@@ -2061,68 +2137,52 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          Value(false), SetMCPConsoleLogging);
 
 #ifndef __EMSCRIPTEN__
-	// Every scalar function below is marked fallible. DuckDB v2.0 turns a throw
-	// from a function that has not declared itself fallible into an INTERNAL
-	// error, and this extension is an RPC surface over an external process:
-	// every one of these can surface a transport failure, a JSON-RPC protocol
-	// error, a rejected tool call or an InvalidInputException on its arguments.
-	// Marking them individually after auditing each call stack would buy nothing
-	// and risks missing one -- and a miss is invisible until a user hits the
-	// error path at runtime. See CompatSetFallible in duckdb_compat.hpp.
+	// Every scalar function below goes through RegisterScalar, which requires a
+	// v2.0 change-class-13 verdict at the call site. See the audit above
+	// RegisterScalar for why all of them are SWALLOWS_ALL.
 	// Register client-side MCP functions (require MCPConnectionRegistry)
 	auto get_resource_func = ScalarFunction("mcp_get_resource", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                        LogicalType::JSON(), MCPGetResourceFunction);
-	CompatSetFallible(get_resource_func);
-	loader.RegisterFunction(get_resource_func);
+	RegisterScalar(loader, get_resource_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto list_resources_func_simple =
 	    ScalarFunction("mcp_list_resources", {LogicalType::VARCHAR}, LogicalType::JSON(), MCPListResourcesFunction);
 	auto list_resources_func_cursor = ScalarFunction("mcp_list_resources", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                                 LogicalType::JSON(), MCPListResourcesWithCursorFunction);
-	CompatSetFallible(list_resources_func_simple);
-	loader.RegisterFunction(list_resources_func_simple);
-	CompatSetFallible(list_resources_func_cursor);
-	loader.RegisterFunction(list_resources_func_cursor);
+	RegisterScalar(loader, list_resources_func_simple, ScalarErrors::SWALLOWS_ALL);
+	RegisterScalar(loader, list_resources_func_cursor, ScalarErrors::SWALLOWS_ALL);
 
 	auto call_tool_func =
 	    ScalarFunction("mcp_call_tool", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::JSON(), MCPCallToolFunction);
-	CompatSetFallible(call_tool_func);
-	loader.RegisterFunction(call_tool_func);
+	RegisterScalar(loader, call_tool_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto list_tools_func_simple =
 	    ScalarFunction("mcp_list_tools", {LogicalType::VARCHAR}, LogicalType::JSON(), MCPListToolsFunction);
 	auto list_tools_func_cursor = ScalarFunction("mcp_list_tools", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                             LogicalType::JSON(), MCPListToolsWithCursorFunction);
-	CompatSetFallible(list_tools_func_simple);
-	loader.RegisterFunction(list_tools_func_simple);
-	CompatSetFallible(list_tools_func_cursor);
-	loader.RegisterFunction(list_tools_func_cursor);
+	RegisterScalar(loader, list_tools_func_simple, ScalarErrors::SWALLOWS_ALL);
+	RegisterScalar(loader, list_tools_func_cursor, ScalarErrors::SWALLOWS_ALL);
 
 	auto list_prompts_func_simple =
 	    ScalarFunction("mcp_list_prompts", {LogicalType::VARCHAR}, LogicalType::JSON(), MCPListPromptsFunction);
 	auto list_prompts_func_cursor = ScalarFunction("mcp_list_prompts", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                               LogicalType::JSON(), MCPListPromptsWithCursorFunction);
-	CompatSetFallible(list_prompts_func_simple);
-	loader.RegisterFunction(list_prompts_func_simple);
-	CompatSetFallible(list_prompts_func_cursor);
-	loader.RegisterFunction(list_prompts_func_cursor);
+	RegisterScalar(loader, list_prompts_func_simple, ScalarErrors::SWALLOWS_ALL);
+	RegisterScalar(loader, list_prompts_func_cursor, ScalarErrors::SWALLOWS_ALL);
 
 	auto get_prompt_func =
 	    ScalarFunction("mcp_get_prompt", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::JSON(), MCPGetPromptFunction);
-	CompatSetFallible(get_prompt_func);
-	loader.RegisterFunction(get_prompt_func);
+	RegisterScalar(loader, get_prompt_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto reconnect_func = ScalarFunction("mcp_reconnect_server", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 	                                     MCPReconnectServerFunction);
-	CompatSetFallible(reconnect_func);
-	loader.RegisterFunction(reconnect_func);
+	RegisterScalar(loader, reconnect_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto health_func =
 	    ScalarFunction("mcp_server_health", {LogicalType::VARCHAR}, LogicalType::VARCHAR, MCPServerHealthFunction);
-	CompatSetFallible(health_func);
-	loader.RegisterFunction(health_func);
+	RegisterScalar(loader, health_func, ScalarErrors::SWALLOWS_ALL);
 #endif // !__EMSCRIPTEN__
 
 	// Server-side functions (work via memory transport in WASM)
@@ -2132,53 +2192,45 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto server_start_simple_func =
 	    ScalarFunction("mcp_server_start", {LogicalType::VARCHAR}, mcp_status_type, MCPServerStartSimpleFunction);
 	PreventStructConstantFolding(server_start_simple_func);
-	CompatSetFallible(server_start_simple_func);
-	loader.RegisterFunction(server_start_simple_func);
+	RegisterScalar(loader, server_start_simple_func, ScalarErrors::SWALLOWS_ALL);
 
 	// mcp_server_start(transport, config_json) - with config for stdio
 	auto server_start_config_func = ScalarFunction("mcp_server_start", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                               mcp_status_type, MCPServerStartConfigFunction);
 	PreventStructConstantFolding(server_start_config_func);
-	CompatSetFallible(server_start_config_func);
-	loader.RegisterFunction(server_start_config_func);
+	RegisterScalar(loader, server_start_config_func, ScalarErrors::SWALLOWS_ALL);
 
 	// mcp_server_start(transport, bind_address, port, config_json) - full form
 	auto server_start_func = ScalarFunction(
 	    "mcp_server_start", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
 	    mcp_status_type, MCPServerStartFunction);
 	PreventStructConstantFolding(server_start_func);
-	CompatSetFallible(server_start_func);
-	loader.RegisterFunction(server_start_func);
+	RegisterScalar(loader, server_start_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto server_stop_func = ScalarFunction("mcp_server_stop", {}, mcp_status_type, MCPServerStopFunction);
 	PreventStructConstantFolding(server_stop_func);
-	CompatSetFallible(server_stop_func);
-	loader.RegisterFunction(server_stop_func);
+	RegisterScalar(loader, server_stop_func, ScalarErrors::SWALLOWS_ALL);
 
 	// mcp_server_stop(force) - with force option for test setup/teardown
 	auto server_stop_force_func =
 	    ScalarFunction("mcp_server_stop", {LogicalType::BOOLEAN}, mcp_status_type, MCPServerStopForceFunction);
 	PreventStructConstantFolding(server_stop_force_func);
-	CompatSetFallible(server_stop_force_func);
-	loader.RegisterFunction(server_stop_force_func);
+	RegisterScalar(loader, server_stop_force_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto server_status_func = ScalarFunction("mcp_server_status", {}, mcp_status_type, MCPServerStatusFunction);
 	PreventStructConstantFolding(server_status_func);
-	CompatSetFallible(server_status_func);
-	loader.RegisterFunction(server_status_func);
+	RegisterScalar(loader, server_status_func, ScalarErrors::SWALLOWS_ALL);
 
 	// Register MCP server test function (for unit testing protocol handling)
 	auto server_test_func =
 	    ScalarFunction("mcp_server_test", {LogicalType::VARCHAR}, LogicalType::VARCHAR, MCPServerTestFunction);
-	CompatSetFallible(server_test_func);
-	loader.RegisterFunction(server_test_func);
+	RegisterScalar(loader, server_test_func, ScalarErrors::SWALLOWS_ALL);
 
 	// Register MCP server send request function - sends request to running server
 	// mcp_server_send_request(request_json) - requires server to be started first
 	auto send_request_func = ScalarFunction("mcp_server_send_request", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 	                                        MCPServerSendRequestFunction);
-	CompatSetFallible(send_request_func);
-	loader.RegisterFunction(send_request_func);
+	RegisterScalar(loader, send_request_func, ScalarErrors::SWALLOWS_ALL);
 
 	// Register resource publishing functions
 	// Note: We use SPECIAL_HANDLING to allow NULL uri/format parameters (which have defaults)
@@ -2186,15 +2238,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    ScalarFunction("mcp_publish_table", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::VARCHAR, MCPPublishTableFunction);
 	SetScalarFunctionNullHandling(publish_table_func, FunctionNullHandling::SPECIAL_HANDLING);
-	CompatSetFallible(publish_table_func);
-	loader.RegisterFunction(publish_table_func);
+	RegisterScalar(loader, publish_table_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto publish_query_func = ScalarFunction(
 	    "mcp_publish_query", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER},
 	    LogicalType::VARCHAR, MCPPublishQueryFunction);
 	SetScalarFunctionNullHandling(publish_query_func, FunctionNullHandling::SPECIAL_HANDLING);
-	CompatSetFallible(publish_query_func);
-	loader.RegisterFunction(publish_query_func);
+	RegisterScalar(loader, publish_query_func, ScalarErrors::SWALLOWS_ALL);
 
 	// mcp_publish_resource(uri, content, mime_type, description)
 	auto publish_resource_func =
@@ -2202,8 +2252,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                   {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::VARCHAR, MCPPublishResourceFunction);
 	SetScalarFunctionNullHandling(publish_resource_func, FunctionNullHandling::SPECIAL_HANDLING);
-	CompatSetFallible(publish_resource_func);
-	loader.RegisterFunction(publish_resource_func);
+	RegisterScalar(loader, publish_resource_func, ScalarErrors::SWALLOWS_ALL);
 
 	// Register tool publishing functions
 	// mcp_publish_tool(name, description, sql_template, properties_json, required_json)
@@ -2212,8 +2261,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	    LogicalType::VARCHAR, MCPPublishToolFunction);
 	SetScalarFunctionNullHandling(publish_tool_func, FunctionNullHandling::SPECIAL_HANDLING);
-	CompatSetFallible(publish_tool_func);
-	loader.RegisterFunction(publish_tool_func);
+	RegisterScalar(loader, publish_tool_func, ScalarErrors::SWALLOWS_ALL);
 
 	// mcp_publish_tool(name, description, sql_template, properties_json, required_json, format)
 	auto publish_tool_format_func = ScalarFunction("mcp_publish_tool",
@@ -2221,8 +2269,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                                                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                               LogicalType::VARCHAR, MCPPublishToolWithFormatFunction);
 	SetScalarFunctionNullHandling(publish_tool_format_func, FunctionNullHandling::SPECIAL_HANDLING);
-	CompatSetFallible(publish_tool_format_func);
-	loader.RegisterFunction(publish_tool_format_func);
+	RegisterScalar(loader, publish_tool_format_func, ScalarErrors::SWALLOWS_ALL);
 
 	// Register execution tool publishing functions
 	// mcp_publish_execution_tool(name, description, sql_template, properties_json, required_json, bindings_json)
@@ -2231,8 +2278,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                                              LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                             LogicalType::VARCHAR, MCPPublishExecutionToolFunction);
 	SetScalarFunctionNullHandling(publish_exec_tool_func, FunctionNullHandling::SPECIAL_HANDLING);
-	CompatSetFallible(publish_exec_tool_func);
-	loader.RegisterFunction(publish_exec_tool_func);
+	RegisterScalar(loader, publish_exec_tool_func, ScalarErrors::SWALLOWS_ALL);
 
 	// mcp_publish_execution_tool(name, description, sql_template, properties_json, required_json, bindings_json,
 	// format)
@@ -2242,31 +2288,26 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::VARCHAR, MCPPublishExecutionToolWithFormatFunction);
 	SetScalarFunctionNullHandling(publish_exec_tool_format_func, FunctionNullHandling::SPECIAL_HANDLING);
-	CompatSetFallible(publish_exec_tool_format_func);
-	loader.RegisterFunction(publish_exec_tool_format_func);
+	RegisterScalar(loader, publish_exec_tool_format_func, ScalarErrors::SWALLOWS_ALL);
 
 	// Register MCP template functions
 	auto register_prompt_template_func = ScalarFunction(
 	    "mcp_register_prompt_template", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	    LogicalType::VARCHAR, MCPRegisterPromptTemplateFunction);
-	CompatSetFallible(register_prompt_template_func);
-	loader.RegisterFunction(register_prompt_template_func);
+	RegisterScalar(loader, register_prompt_template_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto list_prompt_templates_func =
 	    ScalarFunction("mcp_list_prompt_templates", {}, LogicalType::JSON(), MCPListPromptTemplatesFunction);
-	CompatSetFallible(list_prompt_templates_func);
-	loader.RegisterFunction(list_prompt_templates_func);
+	RegisterScalar(loader, list_prompt_templates_func, ScalarErrors::SWALLOWS_ALL);
 
 	auto render_prompt_template_func =
 	    ScalarFunction("mcp_render_prompt_template", {LogicalType::VARCHAR, LogicalType::JSON()}, LogicalType::VARCHAR,
 	                   MCPRenderPromptTemplateFunction);
-	CompatSetFallible(render_prompt_template_func);
-	loader.RegisterFunction(render_prompt_template_func);
+	RegisterScalar(loader, render_prompt_template_func, ScalarErrors::SWALLOWS_ALL);
 
 	// Register MCP diagnostics functions
 	auto diagnostics_func = ScalarFunction("mcp_get_diagnostics", {}, LogicalType::JSON(), MCPGetDiagnosticsFunction);
-	CompatSetFallible(diagnostics_func);
-	loader.RegisterFunction(diagnostics_func);
+	RegisterScalar(loader, diagnostics_func, ScalarErrors::SWALLOWS_ALL);
 
 	// ========================================================================
 	// Register PRAGMA functions (side-effectful functions that produce no output)
@@ -2354,14 +2395,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// mcp_webmcp_sync() - re-sync tools with navigator.modelContext after publishing new tools/resources
 	auto webmcp_sync_func = ScalarFunction("mcp_webmcp_sync", {}, LogicalType::VARCHAR, MCPWebMCPSyncFunction);
-	CompatSetFallible(webmcp_sync_func);
-	loader.RegisterFunction(webmcp_sync_func);
+	RegisterScalar(loader, webmcp_sync_func, ScalarErrors::SWALLOWS_ALL);
 
 	// webmcp_list_page_tools() - list tools registered by other page scripts
 	auto webmcp_list_page_tools_func =
 	    ScalarFunction("webmcp_list_page_tools", {}, LogicalType::JSON(), WebMCPListPageToolsFunction);
-	CompatSetFallible(webmcp_list_page_tools_func);
-	loader.RegisterFunction(webmcp_list_page_tools_func);
+	RegisterScalar(loader, webmcp_list_page_tools_func, ScalarErrors::SWALLOWS_ALL);
 #endif // __EMSCRIPTEN__
 }
 

--- a/src/duckdb_mcp_extension.cpp
+++ b/src/duckdb_mcp_extension.cpp
@@ -2061,48 +2061,67 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          Value(false), SetMCPConsoleLogging);
 
 #ifndef __EMSCRIPTEN__
+	// Every scalar function below is marked fallible. DuckDB v2.0 turns a throw
+	// from a function that has not declared itself fallible into an INTERNAL
+	// error, and this extension is an RPC surface over an external process:
+	// every one of these can surface a transport failure, a JSON-RPC protocol
+	// error, a rejected tool call or an InvalidInputException on its arguments.
+	// Marking them individually after auditing each call stack would buy nothing
+	// and risks missing one -- and a miss is invisible until a user hits the
+	// error path at runtime. See CompatSetFallible in duckdb_compat.hpp.
 	// Register client-side MCP functions (require MCPConnectionRegistry)
 	auto get_resource_func = ScalarFunction("mcp_get_resource", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                        LogicalType::JSON(), MCPGetResourceFunction);
+	CompatSetFallible(get_resource_func);
 	loader.RegisterFunction(get_resource_func);
 
 	auto list_resources_func_simple =
 	    ScalarFunction("mcp_list_resources", {LogicalType::VARCHAR}, LogicalType::JSON(), MCPListResourcesFunction);
 	auto list_resources_func_cursor = ScalarFunction("mcp_list_resources", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                                 LogicalType::JSON(), MCPListResourcesWithCursorFunction);
+	CompatSetFallible(list_resources_func_simple);
 	loader.RegisterFunction(list_resources_func_simple);
+	CompatSetFallible(list_resources_func_cursor);
 	loader.RegisterFunction(list_resources_func_cursor);
 
 	auto call_tool_func =
 	    ScalarFunction("mcp_call_tool", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::JSON(), MCPCallToolFunction);
+	CompatSetFallible(call_tool_func);
 	loader.RegisterFunction(call_tool_func);
 
 	auto list_tools_func_simple =
 	    ScalarFunction("mcp_list_tools", {LogicalType::VARCHAR}, LogicalType::JSON(), MCPListToolsFunction);
 	auto list_tools_func_cursor = ScalarFunction("mcp_list_tools", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                             LogicalType::JSON(), MCPListToolsWithCursorFunction);
+	CompatSetFallible(list_tools_func_simple);
 	loader.RegisterFunction(list_tools_func_simple);
+	CompatSetFallible(list_tools_func_cursor);
 	loader.RegisterFunction(list_tools_func_cursor);
 
 	auto list_prompts_func_simple =
 	    ScalarFunction("mcp_list_prompts", {LogicalType::VARCHAR}, LogicalType::JSON(), MCPListPromptsFunction);
 	auto list_prompts_func_cursor = ScalarFunction("mcp_list_prompts", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                               LogicalType::JSON(), MCPListPromptsWithCursorFunction);
+	CompatSetFallible(list_prompts_func_simple);
 	loader.RegisterFunction(list_prompts_func_simple);
+	CompatSetFallible(list_prompts_func_cursor);
 	loader.RegisterFunction(list_prompts_func_cursor);
 
 	auto get_prompt_func =
 	    ScalarFunction("mcp_get_prompt", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::JSON(), MCPGetPromptFunction);
+	CompatSetFallible(get_prompt_func);
 	loader.RegisterFunction(get_prompt_func);
 
 	auto reconnect_func = ScalarFunction("mcp_reconnect_server", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 	                                     MCPReconnectServerFunction);
+	CompatSetFallible(reconnect_func);
 	loader.RegisterFunction(reconnect_func);
 
 	auto health_func =
 	    ScalarFunction("mcp_server_health", {LogicalType::VARCHAR}, LogicalType::VARCHAR, MCPServerHealthFunction);
+	CompatSetFallible(health_func);
 	loader.RegisterFunction(health_func);
 #endif // !__EMSCRIPTEN__
 
@@ -2113,12 +2132,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto server_start_simple_func =
 	    ScalarFunction("mcp_server_start", {LogicalType::VARCHAR}, mcp_status_type, MCPServerStartSimpleFunction);
 	PreventStructConstantFolding(server_start_simple_func);
+	CompatSetFallible(server_start_simple_func);
 	loader.RegisterFunction(server_start_simple_func);
 
 	// mcp_server_start(transport, config_json) - with config for stdio
 	auto server_start_config_func = ScalarFunction("mcp_server_start", {LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                               mcp_status_type, MCPServerStartConfigFunction);
 	PreventStructConstantFolding(server_start_config_func);
+	CompatSetFallible(server_start_config_func);
 	loader.RegisterFunction(server_start_config_func);
 
 	// mcp_server_start(transport, bind_address, port, config_json) - full form
@@ -2126,31 +2147,37 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "mcp_server_start", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::VARCHAR},
 	    mcp_status_type, MCPServerStartFunction);
 	PreventStructConstantFolding(server_start_func);
+	CompatSetFallible(server_start_func);
 	loader.RegisterFunction(server_start_func);
 
 	auto server_stop_func = ScalarFunction("mcp_server_stop", {}, mcp_status_type, MCPServerStopFunction);
 	PreventStructConstantFolding(server_stop_func);
+	CompatSetFallible(server_stop_func);
 	loader.RegisterFunction(server_stop_func);
 
 	// mcp_server_stop(force) - with force option for test setup/teardown
 	auto server_stop_force_func =
 	    ScalarFunction("mcp_server_stop", {LogicalType::BOOLEAN}, mcp_status_type, MCPServerStopForceFunction);
 	PreventStructConstantFolding(server_stop_force_func);
+	CompatSetFallible(server_stop_force_func);
 	loader.RegisterFunction(server_stop_force_func);
 
 	auto server_status_func = ScalarFunction("mcp_server_status", {}, mcp_status_type, MCPServerStatusFunction);
 	PreventStructConstantFolding(server_status_func);
+	CompatSetFallible(server_status_func);
 	loader.RegisterFunction(server_status_func);
 
 	// Register MCP server test function (for unit testing protocol handling)
 	auto server_test_func =
 	    ScalarFunction("mcp_server_test", {LogicalType::VARCHAR}, LogicalType::VARCHAR, MCPServerTestFunction);
+	CompatSetFallible(server_test_func);
 	loader.RegisterFunction(server_test_func);
 
 	// Register MCP server send request function - sends request to running server
 	// mcp_server_send_request(request_json) - requires server to be started first
 	auto send_request_func = ScalarFunction("mcp_server_send_request", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 	                                        MCPServerSendRequestFunction);
+	CompatSetFallible(send_request_func);
 	loader.RegisterFunction(send_request_func);
 
 	// Register resource publishing functions
@@ -2159,12 +2186,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    ScalarFunction("mcp_publish_table", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::VARCHAR, MCPPublishTableFunction);
 	SetScalarFunctionNullHandling(publish_table_func, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(publish_table_func);
 	loader.RegisterFunction(publish_table_func);
 
 	auto publish_query_func = ScalarFunction(
 	    "mcp_publish_query", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER},
 	    LogicalType::VARCHAR, MCPPublishQueryFunction);
 	SetScalarFunctionNullHandling(publish_query_func, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(publish_query_func);
 	loader.RegisterFunction(publish_query_func);
 
 	// mcp_publish_resource(uri, content, mime_type, description)
@@ -2173,6 +2202,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                   {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::VARCHAR, MCPPublishResourceFunction);
 	SetScalarFunctionNullHandling(publish_resource_func, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(publish_resource_func);
 	loader.RegisterFunction(publish_resource_func);
 
 	// Register tool publishing functions
@@ -2182,6 +2212,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	    LogicalType::VARCHAR, MCPPublishToolFunction);
 	SetScalarFunctionNullHandling(publish_tool_func, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(publish_tool_func);
 	loader.RegisterFunction(publish_tool_func);
 
 	// mcp_publish_tool(name, description, sql_template, properties_json, required_json, format)
@@ -2190,6 +2221,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                                                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                               LogicalType::VARCHAR, MCPPublishToolWithFormatFunction);
 	SetScalarFunctionNullHandling(publish_tool_format_func, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(publish_tool_format_func);
 	loader.RegisterFunction(publish_tool_format_func);
 
 	// Register execution tool publishing functions
@@ -2199,6 +2231,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                                              LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                                             LogicalType::VARCHAR, MCPPublishExecutionToolFunction);
 	SetScalarFunctionNullHandling(publish_exec_tool_func, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(publish_exec_tool_func);
 	loader.RegisterFunction(publish_exec_tool_func);
 
 	// mcp_publish_execution_tool(name, description, sql_template, properties_json, required_json, bindings_json,
@@ -2209,25 +2242,30 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	                   LogicalType::VARCHAR, MCPPublishExecutionToolWithFormatFunction);
 	SetScalarFunctionNullHandling(publish_exec_tool_format_func, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(publish_exec_tool_format_func);
 	loader.RegisterFunction(publish_exec_tool_format_func);
 
 	// Register MCP template functions
 	auto register_prompt_template_func = ScalarFunction(
 	    "mcp_register_prompt_template", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
 	    LogicalType::VARCHAR, MCPRegisterPromptTemplateFunction);
+	CompatSetFallible(register_prompt_template_func);
 	loader.RegisterFunction(register_prompt_template_func);
 
 	auto list_prompt_templates_func =
 	    ScalarFunction("mcp_list_prompt_templates", {}, LogicalType::JSON(), MCPListPromptTemplatesFunction);
+	CompatSetFallible(list_prompt_templates_func);
 	loader.RegisterFunction(list_prompt_templates_func);
 
 	auto render_prompt_template_func =
 	    ScalarFunction("mcp_render_prompt_template", {LogicalType::VARCHAR, LogicalType::JSON()}, LogicalType::VARCHAR,
 	                   MCPRenderPromptTemplateFunction);
+	CompatSetFallible(render_prompt_template_func);
 	loader.RegisterFunction(render_prompt_template_func);
 
 	// Register MCP diagnostics functions
 	auto diagnostics_func = ScalarFunction("mcp_get_diagnostics", {}, LogicalType::JSON(), MCPGetDiagnosticsFunction);
+	CompatSetFallible(diagnostics_func);
 	loader.RegisterFunction(diagnostics_func);
 
 	// ========================================================================
@@ -2316,11 +2354,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// mcp_webmcp_sync() - re-sync tools with navigator.modelContext after publishing new tools/resources
 	auto webmcp_sync_func = ScalarFunction("mcp_webmcp_sync", {}, LogicalType::VARCHAR, MCPWebMCPSyncFunction);
+	CompatSetFallible(webmcp_sync_func);
 	loader.RegisterFunction(webmcp_sync_func);
 
 	// webmcp_list_page_tools() - list tools registered by other page scripts
 	auto webmcp_list_page_tools_func =
 	    ScalarFunction("webmcp_list_page_tools", {}, LogicalType::JSON(), WebMCPListPageToolsFunction);
+	CompatSetFallible(webmcp_list_page_tools_func);
 	loader.RegisterFunction(webmcp_list_page_tools_func);
 #endif // __EMSCRIPTEN__
 }

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -9,87 +9,143 @@
 
 // duckdb_compat.hpp — fleet-standard cross-version shim for DuckDB extensions.
 //
-// Pattern established by @bendrucker in teaguesterling/duckdb_webbed#76 (May 2026):
-// detect the new API via __has_include of headers that moved in the same DuckDB
-// refactor ([duckdb/duckdb#22377](https://github.com/duckdb/duckdb/pull/22377) —
-// "mandatory per-vector size tracking" landed alongside the vector-buffer header
-// reshuffle), then dispatch via a single #ifdef block.
-//
 // Cross-version coverage:
-//   - duckdb v1.4.x / v1.5.x: old API everywhere
-//   - duckdb main / v1.6.x:   new API everywhere
+//   - duckdb v1.5.x (this extension's pin): old API everywhere
+//   - duckdb main / v2.0-cyanoptera:        new API everywhere
 //
-// See teaguesterling/duckdb_markdown's docs/DUCKDB_API_MIGRATION.md for the
-// long-form rationale + upgrade checklist for other extensions.
-
-#if __has_include("duckdb/common/vector/list_vector.hpp")
-#define DUCKDB_HAS_NEW_VECTOR_HEADERS 1
-#include "duckdb/common/vector/list_vector.hpp"
-#include "duckdb/common/vector/struct_vector.hpp"
-#endif
-
-namespace duckdb {
-
-#ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
-
-// --- Output chunk finalization ---
-// DuckDB main mandates per-vector Size() tracking; DataChunk::SetCardinality only
-// updates chunk.count. SetChildCardinality additionally calls FlatVector::SetSize
-// on every column so query operators reading vec.Size() see the right value.
-// Without this, VariadicExecutor (and similar) reports:
-//   "Mismatch in input vector sizes ... expected 0 rows but got N"
-inline void CompatSetOutputCardinality(DataChunk &chunk, idx_t count) {
-	chunk.SetChildCardinality(count);
-}
-
-// --- ScalarFunction property setters (fields are now private) ---
-inline void SetScalarFunctionNullHandling(ScalarFunction &func, FunctionNullHandling handling) {
-	func.SetNullHandling(handling);
-}
-
-// --- Constant folding workaround (from duckdb_webbed PR #76) ---
-// DuckDB main's VectorStructBuffer::SetVectorType throws InternalException when
-// the optimizer constant-folds functions returning STRUCT-containing types
-// (LIST(STRUCT), STRUCT, MAP) due to child size mismatches. Marking them
-// VOLATILE skips constant folding. Semantically correct for mcp_server_*
-// functions anyway — they have side effects (start/stop server, status).
-inline void PreventStructConstantFolding(ScalarFunction &func) {
-	func.SetStability(FunctionStability::VOLATILE);
-}
-
-#else // Old API (v1.4.x / v1.5.x)
-
-inline void CompatSetOutputCardinality(DataChunk &chunk, idx_t count) {
-	chunk.SetCardinality(count);
-}
-
-inline void SetScalarFunctionNullHandling(ScalarFunction &func, FunctionNullHandling handling) {
-	func.null_handling = handling;
-}
-
-// No-op on old API — constant folding works fine for complex types
-inline void PreventStructConstantFolding(ScalarFunction &) {
-}
-
-#endif
-
-//===--------------------------------------------------------------------===//
-// DuckDB v2.0 (main / v2.0-cyanoptera) shims
-//===--------------------------------------------------------------------===//
+// DETECT FEATURES, NOT VERSIONS -- AND NOT PROXY HEADERS EITHER.
 //
-// Everything below is detected by PROBING FOR THE THING ITSELF rather than by a
-// version macro or a proxy header, and each change is probed SEPARATELY. Tying
-// several changes to one macro silently picks the wrong branch the moment they
-// land in different releases -- which, as the CompatName note below records, has
-// already happened once on the v1.5 line.
+// An earlier revision of this header followed the shape established by
+// duckdb_webbed#76: `__has_include("duckdb/common/vector/list_vector.hpp")`,
+// then one `#ifdef` gating every shim at once. That is two mistakes compounded.
 //
-// The probes are written as tag dispatch rather than `if constexpr` so that this
+//  1. A header's PRESENCE is not the change you care about. DuckDB backports
+//     headers to the stable branch without the signature changes that shipped
+//     alongside them on main -- identifier.hpp did exactly that on
+//     v1.5-variegata -- so the probe flips to "new API" on a DuckDB that still
+//     has the old one, and every shim in the file picks the wrong branch at once.
+//  2. One macro for many changes assumes they always land together. They do not
+//     have to, and when they come apart the single #ifdef is guaranteed to be
+//     wrong about all but one of them.
+//
+// So: `#if __has_include(...)` appears below ONLY to decide whether a header can
+// be included, never to decide what an API looks like. Every behavioural shim is
+// selected by probing for the member or the type that actually changed, and each
+// change is probed SEPARATELY.
+//
+// The probes are written as tag dispatch rather than `if constexpr` so this
 // header also compiles at C++11: several extensions in this fleet build their
 // TUs at C++11 on purpose (forcing C++17 on the extension but not on libduckdb
 // gives static-const members in duckdb's headers implicit inline linkage in one
 // set of TUs and not the other, which produces multiple-definition link errors).
 // Tag dispatch has the property that matters here -- only the selected overload
 // is instantiated, so the branch naming an absent member is never compiled.
+//
+// See teaguesterling/duckdb_markdown's docs/duckdb_v2_migration.md for the
+// long-form rationale + upgrade checklist for other extensions.
+
+// v2.0 split the per-vector accessor classes out of
+// duckdb/common/types/vector.hpp into one header each under
+// duckdb/common/vector/, and duckdb.hpp no longer pulls them in transitively.
+// Included (not probed-on) so that TUs naming ListVector/StructVector at
+// namespace scope keep compiling; the absence of these headers is not used to
+// infer anything about any API.
+#if __has_include("duckdb/common/vector/list_vector.hpp")
+#include "duckdb/common/vector/list_vector.hpp"
+#endif
+#if __has_include("duckdb/common/vector/struct_vector.hpp")
+#include "duckdb/common/vector/struct_vector.hpp"
+#endif
+
+namespace duckdb {
+
+// --- Output chunk finalization (change class 18) ------------------------------
+// v2.0 gives every Vector its own size, and DataChunk::SetCardinality no longer
+// sets it -- it updates only the chunk's count. Vector::SetValue writes AT AN
+// INDEX and never advances a vector's size, so a table function that fills its
+// output with SetValue and then calls SetCardinality leaves every child vector
+// at size 0.
+//
+// The failure is SILENT, which is what makes it worth a shim rather than a fix
+// at the call site. Readers that go through the chunk count -- the printer,
+// scalar functions -- are correct, so casual testing passes. `IS NULL` iterates
+// the VECTOR's size, finds zero rows, writes nothing, and the result buffer
+// keeps its default `false`. So `SELECT c` prints NULL while `SELECT c IS NULL`
+// returns false, in the same result set, with no exception and a green build.
+//
+// SetChildCardinality is the call that sizes the children, and for an
+// index-writing caller it is REQUIRED, not merely safe. (It would be a no-op for
+// a caller that filled the chunk with Vector::Append, which advances v_size as
+// it goes -- this extension has no such caller: `grep -rn '\.Append(\|AppendValue' src/`
+// is empty, and every table-function scan here writes with DataChunk::SetValue.)
+//
+// Probed on the member itself. The header probe this replaced keyed off
+// list_vector.hpp, which shipped in the same upstream PR as per-vector size
+// tracking -- true today, and an assumption with no reason to keep holding.
+template <class T, class = void>
+struct CompatHasSetChildCardinality : std::false_type {};
+template <class T>
+struct CompatHasSetChildCardinality<T, decltype(void(std::declval<T &>().SetChildCardinality(idx_t(0))))>
+    : std::true_type {};
+
+// The Impl overloads MUST be templates. Tag dispatch only defers compilation of
+// the unselected branch when that branch is a template -- a non-template
+// overload naming an absent member is a hard error at declaration time,
+// whichever tag is passed. (Observed: "class duckdb::DataChunk has no member
+// named SetChildCardinality" on the pinned build, from the branch that is never
+// called there.)
+template <class CHUNK>
+inline void CompatSetOutputCardinalityImpl(CHUNK &chunk, idx_t count, std::true_type) {
+	chunk.SetChildCardinality(count);
+}
+template <class CHUNK>
+inline void CompatSetOutputCardinalityImpl(CHUNK &chunk, idx_t count, std::false_type) {
+	chunk.SetCardinality(count);
+}
+//! Finalise a table function's output chunk. Use this rather than
+//! DataChunk::SetCardinality anywhere the chunk was filled with SetValue.
+inline void CompatSetOutputCardinality(DataChunk &chunk, idx_t count) {
+	CompatSetOutputCardinalityImpl(chunk, count, CompatHasSetChildCardinality<DataChunk>());
+}
+
+// --- ScalarFunction property setters ------------------------------------------
+// v2.0 made BaseScalarFunction's property fields private behind accessors. The
+// accessors (SetNullHandling, SetStability, SetFallible, ...) are ALSO present
+// on the pinned v1.5 -- verified at function.hpp:192-217 of the pin -- so there
+// is nothing to branch on: call the accessor on both lines. Reaching for
+// `func.null_handling = ...` on v1.5 only creates a v2.0 compile error for no
+// benefit.
+inline void SetScalarFunctionNullHandling(ScalarFunction &func, FunctionNullHandling handling) {
+	func.SetNullHandling(handling);
+}
+
+// --- Constant folding workaround (from duckdb_webbed PR #76) ------------------
+// DuckDB main's VectorStructBuffer::SetVectorType throws InternalException when
+// the optimizer constant-folds a function returning a STRUCT-containing type
+// (LIST(STRUCT), STRUCT, MAP), because of the child-size mismatch described
+// above. Marking such a function VOLATILE skips constant folding.
+//
+// Deliberately still conditional, and deliberately NOT applied on the pinned
+// line: VOLATILE is optimizer-visible, and this shim exists to avoid a v2.0
+// crash rather than to restate a property. (An argument exists that mcp_server_*
+// should be VOLATILE on both lines on its own merits -- they start and stop a
+// server -- but that is a behaviour change to the shipped binary and belongs in
+// its own commit with its own measurement, not smuggled in under a compat shim.)
+//
+// Gated on the per-vector-size-tracking probe above rather than on a header,
+// because that IS the upstream change that produces the child-size mismatch.
+inline void PreventStructConstantFoldingImpl(ScalarFunction &func, std::true_type) {
+	func.SetStability(FunctionStability::VOLATILE);
+}
+inline void PreventStructConstantFoldingImpl(ScalarFunction &, std::false_type) {
+}
+inline void PreventStructConstantFolding(ScalarFunction &func) {
+	PreventStructConstantFoldingImpl(func, CompatHasSetChildCardinality<DataChunk>());
+}
+
+//===--------------------------------------------------------------------===//
+// DuckDB v2.0 (main / v2.0-cyanoptera) shims
+//===--------------------------------------------------------------------===//
 
 // --- Detection: does this DuckDB have duckdb::Identifier? --------------------
 // Needed only so that CompatNameStr can accept one. It is NOT used to decide
@@ -116,14 +172,34 @@ inline void PreventStructConstantFolding(ScalarFunction &) {
 //   main (v2.0):                         HAS identifier.hpp,  bind: vector<Identifier>
 //
 // So on the next submodule bump a header probe starts reporting "v2.0 names" on
-// a v1.5 that still wants strings, and every bind signature stops compiling. The
-// probe below cannot drift: CompatName is *defined as* whatever element type this
-// DuckDB's own bind input uses for column names.
+// a v1.5 that still wants strings, and every bind signature stops compiling.
+//
+// AND BE PRECISE ABOUT *WHICH* DECLARATION YOU DERIVE FROM. "Some container of
+// names in the same header" is the right kind of answer aimed at the wrong
+// thing. Three separate upstream declarations all flipped string -> Identifier
+// in v2.0 and they agree TODAY, but they are independent and can be changed,
+// backported or reverted one at a time:
+//
+//   table_function_bind_t's 4th parameter   <- the bind-name boundary (THIS one)
+//   TableFunctionBindInput::input_table_names <- names of INPUT TABLES to a
+//                                                table-in/table-out function
+//   child_list_t<T>'s key                   <- STRUCT FIELD names
+//
+// An earlier revision of this header read the type off `input_table_names`,
+// which is a sibling that happens to move in step. The thing this alias exists
+// to describe is the out-parameter every bind callback in this extension has to
+// declare, so derive it from the typedef of that callback itself. Then there is
+// no "happens to" left: the type named IS the type that changed, and every bind
+// signature follows automatically.
+template <class T>
+struct CompatBindNamesOf;
+template <class R, class A, class B, class C, class D>
+struct CompatBindNamesOf<R (*)(A, B, C, D)> {
+	using type = typename std::remove_reference<D>::type::value_type;
+};
 //! The type DuckDB uses for column names in bind signatures: `string` on v1.5,
-//! `Identifier` on v2.0. Read off the container's own value_type so it does not
-//! depend on duckdb::vector's template parameter list either.
-using CompatName = std::remove_reference<decltype(std::declval<TableFunctionBindInput &>()
-                                                      .input_table_names)>::type::value_type;
+//! `Identifier` on v2.0.
+using CompatName = CompatBindNamesOf<table_function_bind_t>::type;
 
 //! Read a name back out as a plain string. Both overloads exist wherever both
 //! types do; on v2.0 Identifier -> string is explicit, so this is the opt-in.
@@ -131,10 +207,21 @@ inline string CompatNameStr(const string &name) {
 	return name;
 }
 #ifdef DUCKDB_HAS_IDENTIFIER
+// Declares the Identifier overload only; it does NOT decide what CompatName is.
+// Both overloads coexist happily on a DuckDB that has Identifier but still binds
+// with strings -- which is exactly the v1.5 branch tip.
 inline string CompatNameStr(const Identifier &name) {
 	return name.GetIdentifierName();
 }
 #endif
+
+// PIN THE DERIVATION. Deriving CompatName fixes the type but leaves a second
+// failure mode open: CompatName could resolve to Identifier on a DuckDB whose
+// identifier.hpp this header did not find, so the overload above was never
+// declared -- and then CompatNameStr either fails to match or silently picks a
+// worse conversion. Assert the coupling rather than assuming it.
+static_assert(std::is_same<decltype(CompatNameStr(std::declval<const CompatName &>())), string>::value,
+              "CompatNameStr must accept the derived CompatName on every DuckDB line");
 
 //! Promote a RUNTIME string to a bind name. Literals need no helper --
 //! `names.emplace_back("file_path")` compiles unchanged on both versions,
@@ -226,18 +313,48 @@ struct CompatHasResultGetNames : std::false_type {};
 template <class T>
 struct CompatHasResultGetNames<T, decltype(void(std::declval<const T &>().GetNames()))> : std::true_type {};
 
+// DELIBERATELY NOT `vector<CompatName>`. Result column names and table-function
+// bind names are two DIFFERENT upstream declarations (change class 17 vs class
+// 2) that both flipped string -> Identifier in v2.0. They agree today, which is
+// exactly what makes writing `vector<CompatName>` here feel harmless -- and it
+// is the same mistake as probing identifier.hpp: it silently binds this shim's
+// correctness to a change it does not describe. Read the container type off the
+// result itself so the two can diverge without breaking either.
+//
+// A class-template specialisation rather than an overload pair: only the
+// selected specialisation is instantiated, so the v1.5 branch naming the (on
+// v2.0 private) `names` member is never compiled there, and there is no
+// overload-resolution substitution to reason about.
+template <class RESULT, bool HAS_ACCESSOR>
+struct CompatResultNamesTypeImpl;
 template <class RESULT>
-inline const vector<CompatName> &CompatResultNamesImpl(const RESULT &result, std::true_type) {
+struct CompatResultNamesTypeImpl<RESULT, true> {
+	using type = typename std::remove_const<
+	    typename std::remove_reference<decltype(std::declval<const RESULT &>().GetNames())>::type>::type;
+};
+template <class RESULT>
+struct CompatResultNamesTypeImpl<RESULT, false> {
+	using type = typename std::remove_const<
+	    typename std::remove_reference<decltype(std::declval<const RESULT &>().names)>::type>::type;
+};
+//! The container a query result stores its column names in: vector<string> on
+//! v1.5, vector<Identifier> on v2.0.
+template <class RESULT>
+struct CompatResultNamesType : CompatResultNamesTypeImpl<RESULT, CompatHasResultGetNames<RESULT>::value> {};
+
+template <class RESULT>
+inline const typename CompatResultNamesType<RESULT>::type &CompatResultNamesImpl(const RESULT &result, std::true_type) {
 	return result.GetNames();
 }
 template <class RESULT>
-inline const vector<CompatName> &CompatResultNamesImpl(const RESULT &result, std::false_type) {
+inline const typename CompatResultNamesType<RESULT>::type &CompatResultNamesImpl(const RESULT &result,
+                                                                                 std::false_type) {
 	return result.names;
 }
-//! The column names of a query result. Elements are CompatName -- run one through
-//! CompatNameStr to use it as a string.
+//! The column names of a query result. Run an element through CompatNameStr to
+//! use it as a string.
 template <class RESULT>
-inline const vector<CompatName> &CompatResultNames(const RESULT &result) {
+inline const typename CompatResultNamesType<RESULT>::type &CompatResultNames(const RESULT &result) {
 	return CompatResultNamesImpl(result, CompatHasResultGetNames<RESULT>());
 }
 
@@ -324,9 +441,8 @@ struct CompatHasNamedParamMapAccessor<T, decltype(void(std::declval<const T &>()
 //! The map type PreparedStatement::Execute accepts for named parameters.
 #ifdef DUCKDB_HAS_IDENTIFIER
 template <class VALUE>
-using CompatNamedParamMap =
-    typename std::conditional<CompatHasNamedParamMapAccessor<PreparedStatement>::value, identifier_map_t<VALUE>,
-                              case_insensitive_map_t<VALUE>>::type;
+using CompatNamedParamMap = typename std::conditional<CompatHasNamedParamMapAccessor<PreparedStatement>::value,
+                                                      identifier_map_t<VALUE>, case_insensitive_map_t<VALUE>>::type;
 #else
 template <class VALUE>
 using CompatNamedParamMap = case_insensitive_map_t<VALUE>;

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -414,8 +414,15 @@ inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::false_type)
 	return const_cast<ValidityMask &>(FV::Validity(vec));
 }
 template <class FV = FlatVector>
-inline ValidityMask &CompatGetValidityMutable(Vector &vec) {
+inline ValidityMask &CompatFlatValidityMutable(Vector &vec) {
 	return CompatFlatValidityMutableImpl<FV>(vec, CompatHasFlatValidityMutable<FV>());
+}
+
+//! Long-standing spelling in this repo; the fleet-standard name is
+//! CompatFlatValidityMutable. Kept as a forwarder so the call sites do not churn.
+template <class FV = FlatVector>
+inline ValidityMask &CompatGetValidityMutable(Vector &vec) {
+	return CompatFlatValidityMutable<FV>(vec);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -260,6 +260,39 @@ inline bool CompatHasNamedParam(const STMT &stmt, const NAME &name) {
 	return CompatHasNamedParamImpl(stmt, name, CompatHasNamedParamMapAccessor<STMT>());
 }
 
+// --- Fallible scalar functions ------------------------------------------------
+// v2.0 requires a scalar function that can throw at EXECUTION time to say so.
+// Throwing from one that has not becomes:
+//
+//   INTERNAL Error: Scalar function "f" threw an execution error, but the
+//   function is not marked as fallible - the function must call SetFallible().
+//
+// This is not a compile error and nothing in the API is greppable for it. The
+// only symptom is a test that exercises an error path, and enforcement is an
+// assertion -- so one CI arch can be green while another is red on the very same
+// commit, purely because only one image builds with assertions on.
+//
+// BaseScalarFunction::SetFallible() also exists on the pinned v1.5 (it just is
+// not enforced there), so this is a shim only for the sake of an older pin.
+// Must be called BEFORE the function goes into a FunctionSet, since v2.0's set
+// members are no longer mutable.
+template <class T, class = void>
+struct CompatHasSetFallible : std::false_type {};
+template <class T>
+struct CompatHasSetFallible<T, decltype(void(std::declval<T &>().SetFallible()))> : std::true_type {};
+
+template <class FUNC>
+inline void CompatSetFallibleImpl(FUNC &fun, std::true_type) {
+	fun.SetFallible();
+}
+template <class FUNC>
+inline void CompatSetFallibleImpl(FUNC &, std::false_type) {
+}
+template <class FUNC>
+inline void CompatSetFallible(FUNC &fun) {
+	CompatSetFallibleImpl(fun, CompatHasSetFallible<FUNC>());
+}
+
 // --- LogicalType alias --------------------------------------------------------
 // v1.5: void SetAlias(string)                -- mutates in place
 // v2.0: LogicalType WithAlias(string) const  -- returns a copy, never mutating a

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb/function/table_function.hpp"
+#include <type_traits>
+#include <utility>
 
 // duckdb_compat.hpp — fleet-standard cross-version shim for DuckDB extensions.
 //
@@ -82,6 +85,226 @@ inline T *CompatGetDataMutable(Vector &vec) {
 
 inline ValidityMask &CompatGetValidityMutable(Vector &vec) {
 	return const_cast<ValidityMask &>(FlatVector::Validity(vec));
+}
+
+//===--------------------------------------------------------------------===//
+// DuckDB v2.0 (main / v2.0-cyanoptera) shims
+//===--------------------------------------------------------------------===//
+//
+// Everything below is detected by PROBING FOR THE THING ITSELF rather than by a
+// version macro or a proxy header, and each change is probed SEPARATELY. Tying
+// several changes to one macro silently picks the wrong branch the moment they
+// land in different releases -- which, as the CompatName note below records, has
+// already happened once on the v1.5 line.
+//
+// The probes are written as tag dispatch rather than `if constexpr` so that this
+// header also compiles at C++11: several extensions in this fleet build their
+// TUs at C++11 on purpose (forcing C++17 on the extension but not on libduckdb
+// gives static-const members in duckdb's headers implicit inline linkage in one
+// set of TUs and not the other, which produces multiple-definition link errors).
+// Tag dispatch has the property that matters here -- only the selected overload
+// is instantiated, so the branch naming an absent member is never compiled.
+
+// --- Detection: does this DuckDB have duckdb::Identifier? --------------------
+// Needed only so that CompatNameStr can accept one. It is NOT used to decide
+// what CompatName is -- see the note on that below.
+#if __has_include("duckdb/common/identifier.hpp")
+#define DUCKDB_HAS_IDENTIFIER 1
+#include "duckdb/common/identifier.hpp"
+#endif
+
+// --- bind-signature name type ------------------------------------------------
+// v2.0 replaced std::string with duckdb::Identifier as the name type in
+// table-function and COPY bind signatures. Identifier compares case-insensitively,
+// and on v2.0 construction from a RUNTIME string is explicit by design, so a
+// boundary helper is needed rather than an implicit conversion.
+//
+// NOTE ON THE PROBE. The obvious probe -- __has_include of identifier.hpp -- is
+// WRONG, and the fleet's other headers currently get this wrong. The v1.5 line
+// backported duckdb/common/identifier.hpp (with implicit string<->Identifier
+// conversions) WITHOUT changing table_function_bind_t, which still takes
+// `vector<string> &names` there:
+//
+//   v1.5-variegata @ b155d6f6 (our pin): no identifier.hpp,   bind: vector<string>
+//   v1.5-variegata @ branch tip:         HAS identifier.hpp,  bind: vector<string>
+//   main (v2.0):                         HAS identifier.hpp,  bind: vector<Identifier>
+//
+// So on the next submodule bump a header probe starts reporting "v2.0 names" on
+// a v1.5 that still wants strings, and every bind signature stops compiling. The
+// probe below cannot drift: CompatName is *defined as* whatever element type this
+// DuckDB's own bind input uses for column names.
+//! The type DuckDB uses for column names in bind signatures: `string` on v1.5,
+//! `Identifier` on v2.0. Read off the container's own value_type so it does not
+//! depend on duckdb::vector's template parameter list either.
+using CompatName = std::remove_reference<decltype(std::declval<TableFunctionBindInput &>()
+                                                      .input_table_names)>::type::value_type;
+
+//! Read a name back out as a plain string. Both overloads exist wherever both
+//! types do; on v2.0 Identifier -> string is explicit, so this is the opt-in.
+inline string CompatNameStr(const string &name) {
+	return name;
+}
+#ifdef DUCKDB_HAS_IDENTIFIER
+inline string CompatNameStr(const Identifier &name) {
+	return name.GetIdentifierName();
+}
+#endif
+
+//! Promote a RUNTIME string to a bind name. Literals need no helper --
+//! `names.emplace_back("file_path")` compiles unchanged on both versions,
+//! because Identifier's constructor from a string literal stays implicit.
+inline CompatName CompatMakeName(string name) {
+	return CompatName(std::move(name));
+}
+
+// --- Catalog parsed-data: name/schema fields became accessors -----------------
+// v2.0 folded catalog/schema/name into a single private QualifiedName on
+// CreateInfo and DropInfo, so `info.schema` and `info.name` no longer exist.
+// This is not covered by the migration guide; it only bites extensions that
+// implement their own Catalog/SchemaCatalogEntry (i.e. a storage extension).
+//
+//   v1.5 @ our pin:  CreateInfo::schema, DropInfo::name           (public fields)
+//   v2.0:            GetQualifiedName().Schema() / .Name()        (accessors)
+//
+// Probed on GetQualifiedName rather than on the absent field, so the new branch
+// is the one selected whenever it is available. The v1.5 branch tip backported
+// GetQualifiedName too, where it returns by VALUE -- hence every helper here
+// copies out of it inside a single full-expression and never binds a reference.
+template <class T, class = void>
+struct CompatHasQualifiedName : std::false_type {};
+template <class T>
+struct CompatHasQualifiedName<T, decltype(void(std::declval<const T &>().GetQualifiedName()))> : std::true_type {};
+
+template <class INFO>
+inline string CompatEntryNameImpl(const INFO &info, std::true_type) {
+	return CompatNameStr(info.GetQualifiedName().Name());
+}
+template <class INFO>
+inline string CompatEntryNameImpl(const INFO &info, std::false_type) {
+	return info.name;
+}
+//! The name of the entry a DropInfo refers to.
+template <class INFO>
+inline string CompatEntryName(const INFO &info) {
+	return CompatEntryNameImpl(info, CompatHasQualifiedName<INFO>());
+}
+
+template <class INFO>
+inline string CompatSchemaNameImpl(const INFO &info, std::true_type) {
+	return CompatNameStr(info.GetQualifiedName().Schema());
+}
+template <class INFO>
+inline string CompatSchemaNameImpl(const INFO &info, std::false_type) {
+	return info.schema;
+}
+//! The schema a CreateInfo refers to. For CreateSchemaInfo this is the schema
+//! BEING CREATED: v2.0 stores it in the Schema() slot of the qualified name
+//! (that is exactly what CreateSchemaInfo::SchemaName() reads), and v1.5 stores
+//! it in CreateInfo::schema.
+template <class INFO>
+inline string CompatSchemaName(const INFO &info) {
+	return CompatSchemaNameImpl(info, CompatHasQualifiedName<INFO>());
+}
+
+// Probed separately from the getter: the setter and the getter are different
+// members and there is no guarantee they arrive together.
+template <class T, class = void>
+struct CompatHasSetSchema : std::false_type {};
+template <class T>
+struct CompatHasSetSchema<T, decltype(void(std::declval<T &>().SetSchema(std::declval<CompatName>())))>
+    : std::true_type {};
+
+template <class INFO>
+inline void CompatSetSchemaNameImpl(INFO &info, string name, std::true_type) {
+	info.SetSchema(CompatMakeName(std::move(name)));
+}
+template <class INFO>
+inline void CompatSetSchemaNameImpl(INFO &info, string name, std::false_type) {
+	info.schema = std::move(name);
+}
+//! Set the schema a CreateInfo refers to; see CompatSchemaName for what that
+//! means on a CreateSchemaInfo.
+template <class INFO>
+inline void CompatSetSchemaName(INFO &info, string name) {
+	CompatSetSchemaNameImpl(info, std::move(name), CompatHasSetSchema<INFO>());
+}
+
+// --- LogicalType alias --------------------------------------------------------
+// v1.5: void SetAlias(string)                -- mutates in place
+// v2.0: LogicalType WithAlias(string) const  -- returns a copy, never mutating a
+//       type whose type-info may be shared. SetAlias is REMOVED, not deprecated.
+//
+// Unused in this extension today; carried so the fleet's compat headers stay
+// interchangeable. (Note for anyone porting a call site: SetAlias was a setter,
+// so calling it twice REPLACED the alias rather than adding one -- only the last
+// call ever took effect.)
+template <class T, class = void>
+struct CompatHasWithAlias : std::false_type {};
+template <class T>
+struct CompatHasWithAlias<T, decltype(void(std::declval<const T &>().WithAlias(string())))> : std::true_type {};
+
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::true_type) {
+	return type.WithAlias(std::move(alias));
+}
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::false_type) {
+	type.SetAlias(std::move(alias));
+	return type;
+}
+template <class TYPE = LogicalType>
+inline LogicalType CompatWithAlias(TYPE type, string alias) {
+	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<TYPE>());
+}
+
+// --- Vector::ToUnifiedFormat ---------------------------------------------------
+// v2.0 dropped the count parameter (the old form is deprecated, not removed).
+// Unused in this extension today; carried for fleet interchangeability.
+template <class T, class = void>
+struct CompatToUnifiedTakesCount : std::false_type {};
+template <class T>
+struct CompatToUnifiedTakesCount<T, decltype(void(std::declval<T &>().ToUnifiedFormat(
+                                        idx_t(0), std::declval<UnifiedVectorFormat &>())))> : std::true_type {};
+
+template <class VEC>
+inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t count, UnifiedVectorFormat &data, std::true_type) {
+	vec.ToUnifiedFormat(count, data);
+}
+template <class VEC>
+inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t, UnifiedVectorFormat &data, std::false_type) {
+	vec.ToUnifiedFormat(data);
+}
+template <class VEC = Vector>
+inline void CompatToUnifiedFormat(VEC &vec, idx_t count, UnifiedVectorFormat &data) {
+	CompatToUnifiedFormatImpl(vec, count, data, CompatToUnifiedTakesCount<VEC>());
+}
+
+// --- FlatVector mutable data ---------------------------------------------------
+// v1.5: FlatVector::GetData<T>(vec)         returns T*
+// v2.0: FlatVector::GetData<T>(vec)         returns const T*
+//       FlatVector::GetDataMutable<T>(vec)  returns T*
+//
+// CompatGetDataMutable above already covers this repo's ~30 write sites with a
+// const_cast, which is well-defined here (the buffer is not really const) and is
+// left in place rather than churned. This is the fleet-standard spelling that
+// asks for mutability through the real v2.0 accessor.
+template <class T, class = void>
+struct CompatHasFlatGetDataMutable : std::false_type {};
+template <class T>
+struct CompatHasFlatGetDataMutable<T, decltype(void(T::template GetDataMutable<bool>(std::declval<Vector &>())))>
+    : std::true_type {};
+
+template <class VALUE, class FV>
+inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::true_type) {
+	return FV::template GetDataMutable<VALUE>(vec);
+}
+template <class VALUE, class FV>
+inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::false_type) {
+	return FV::template GetData<VALUE>(vec);
+}
+template <class VALUE, class FV = FlatVector>
+inline VALUE *CompatFlatDataMutable(Vector &vec) {
+	return CompatFlatDataMutableImpl<VALUE, FV>(vec, CompatHasFlatGetDataMutable<FV>());
 }
 
 } // namespace duckdb

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -215,6 +215,92 @@ inline void CompatSetSchemaName(INFO &info, string name) {
 	CompatSetSchemaNameImpl(info, std::move(name), CompatHasSetSchema<INFO>());
 }
 
+// --- QueryResult names and types ----------------------------------------------
+// v1.5: BaseQueryResult::names (vector<string>) and ::types are PUBLIC fields
+// v2.0: both are private; GetNames() -> const vector<Identifier> &
+//                        GetTypes() -> const vector<LogicalType> &
+//
+// The accessors do not exist on v1.5, so this is a positive v2.0 probe.
+template <class T, class = void>
+struct CompatHasResultGetNames : std::false_type {};
+template <class T>
+struct CompatHasResultGetNames<T, decltype(void(std::declval<const T &>().GetNames()))> : std::true_type {};
+
+template <class RESULT>
+inline const vector<CompatName> &CompatResultNamesImpl(const RESULT &result, std::true_type) {
+	return result.GetNames();
+}
+template <class RESULT>
+inline const vector<CompatName> &CompatResultNamesImpl(const RESULT &result, std::false_type) {
+	return result.names;
+}
+//! The column names of a query result. Elements are CompatName -- run one through
+//! CompatNameStr to use it as a string.
+template <class RESULT>
+inline const vector<CompatName> &CompatResultNames(const RESULT &result) {
+	return CompatResultNamesImpl(result, CompatHasResultGetNames<RESULT>());
+}
+
+template <class T, class = void>
+struct CompatHasResultGetTypes : std::false_type {};
+template <class T>
+struct CompatHasResultGetTypes<T, decltype(void(std::declval<const T &>().GetTypes()))> : std::true_type {};
+
+template <class RESULT>
+inline const vector<LogicalType> &CompatResultTypesImpl(const RESULT &result, std::true_type) {
+	return result.GetTypes();
+}
+template <class RESULT>
+inline const vector<LogicalType> &CompatResultTypesImpl(const RESULT &result, std::false_type) {
+	return result.types;
+}
+//! The column types of a query result.
+template <class RESULT>
+inline const vector<LogicalType> &CompatResultTypes(const RESULT &result) {
+	return CompatResultTypesImpl(result, CompatHasResultGetTypes<RESULT>());
+}
+
+// --- STRUCT field names -------------------------------------------------------
+// child_list_t<T> is vector<pair<string, T>> on v1.5 and vector<pair<Identifier, T>>
+// on v2.0, and StructType::GetChildName returns the matching type.
+//
+// This one is worth reading twice, because the compiler will NOT catch the part
+// that matters. `field_name == "name"` keeps compiling on v2.0 -- Identifier has
+// operator== against const char* and string -- but Identifier's equality is
+// CASE-INSENSITIVE, so a comparison that was exact on v1.5 silently starts
+// matching "Name" and "NAME" on v2.0. These are JSON-RPC object keys off the
+// wire, where case-sensitive is the protocol's rule, so every comparison goes
+// through the raw string and keeps the v1.5 behaviour on both versions.
+inline string CompatStructFieldName(const LogicalType &type, idx_t index) {
+	return CompatNameStr(StructType::GetChildName(type, index));
+}
+
+// --- Value type reinterpretation ----------------------------------------------
+// v1.5: void Value::Reinterpret(LogicalType)   -- mutates in place
+// v2.0: Value Value::WithType(LogicalType) const -- returns a copy
+// Neither converts the underlying value; both just relabel its type. (The cast
+// is DefaultCastAs, which is a different thing and is unchanged.)
+template <class T, class = void>
+struct CompatHasValueWithType : std::false_type {};
+template <class T>
+struct CompatHasValueWithType<T, decltype(void(std::declval<const T &>().WithType(std::declval<LogicalType>())))>
+    : std::true_type {};
+
+template <class VALUE>
+inline VALUE CompatWithTypeImpl(VALUE value, LogicalType type, std::true_type) {
+	return value.WithType(std::move(type));
+}
+template <class VALUE>
+inline VALUE CompatWithTypeImpl(VALUE value, LogicalType type, std::false_type) {
+	value.Reinterpret(std::move(type));
+	return value;
+}
+//! Concrete entry point on purpose -- see the note on CompatWithAlias about why a
+//! defaulted template parameter is the wrong shape here.
+inline Value CompatWithType(Value value, LogicalType type) {
+	return CompatWithTypeImpl(std::move(value), std::move(type), CompatHasValueWithType<Value>());
+}
+
 // --- Prepared statement named parameters --------------------------------------
 // v2.0 re-keyed the named-parameter maps on Identifier and moved the map behind
 // an accessor:

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -2,6 +2,8 @@
 
 #include "duckdb.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/main/prepared_statement.hpp"
+#include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include <type_traits>
 #include <utility>
 
@@ -70,22 +72,6 @@ inline void PreventStructConstantFolding(ScalarFunction &) {
 }
 
 #endif
-
-// --- Direct flat-vector writes (cross-version) ---
-// DuckDB main's FlatVector::GetData<T>(Vector&) and FlatVector::Validity(Vector&)
-// return const-qualified by default; new GetDataMutable<T> / ValidityMutable
-// overloads exist for writes. On v1.4.x/v1.5.x the returns are already non-const,
-// so the const_cast is a no-op there.
-//
-// See duckdb_markdown's docs/DUCKDB_API_MIGRATION.md §4 for the long-form rationale.
-template <typename T>
-inline T *CompatGetDataMutable(Vector &vec) {
-	return const_cast<T *>(FlatVector::GetData<T>(vec));
-}
-
-inline ValidityMask &CompatGetValidityMutable(Vector &vec) {
-	return const_cast<ValidityMask &>(FlatVector::Validity(vec));
-}
 
 //===--------------------------------------------------------------------===//
 // DuckDB v2.0 (main / v2.0-cyanoptera) shims
@@ -229,6 +215,51 @@ inline void CompatSetSchemaName(INFO &info, string name) {
 	CompatSetSchemaNameImpl(info, std::move(name), CompatHasSetSchema<INFO>());
 }
 
+// --- Prepared statement named parameters --------------------------------------
+// v2.0 re-keyed the named-parameter maps on Identifier and moved the map behind
+// an accessor:
+//
+//   v1.5:  PreparedStatement::named_param_map      case_insensitive_map_t<idx_t>   (public field)
+//          Execute(case_insensitive_map_t<BoundParameterData> &)
+//   v2.0:  PreparedStatement::GetNamedParameterMap()  identifier_map_t<idx_t>
+//          Execute(identifier_map_t<BoundParameterData> &)
+//
+// Probed on the v2.0-only accessor. Deliberately NOT probed by trying to call
+// Execute with an identifier_map_t: PreparedStatement has a variadic
+// `template <class... ARGS> Execute(ARGS...)` overload that swallows any
+// argument, so such a probe answers "yes" on both versions and then fails deep
+// inside the variadic instantiation.
+template <class T, class = void>
+struct CompatHasNamedParamMapAccessor : std::false_type {};
+template <class T>
+struct CompatHasNamedParamMapAccessor<T, decltype(void(std::declval<const T &>().GetNamedParameterMap()))>
+    : std::true_type {};
+
+//! The map type PreparedStatement::Execute accepts for named parameters.
+#ifdef DUCKDB_HAS_IDENTIFIER
+template <class VALUE>
+using CompatNamedParamMap =
+    typename std::conditional<CompatHasNamedParamMapAccessor<PreparedStatement>::value, identifier_map_t<VALUE>,
+                              case_insensitive_map_t<VALUE>>::type;
+#else
+template <class VALUE>
+using CompatNamedParamMap = case_insensitive_map_t<VALUE>;
+#endif
+
+template <class STMT, class NAME>
+inline bool CompatHasNamedParamImpl(const STMT &stmt, const NAME &name, std::true_type) {
+	return stmt.GetNamedParameterMap().count(name) > 0;
+}
+template <class STMT, class NAME>
+inline bool CompatHasNamedParamImpl(const STMT &stmt, const NAME &name, std::false_type) {
+	return stmt.named_param_map.count(name) > 0;
+}
+//! Does this prepared statement declare a parameter with this name?
+template <class STMT, class NAME>
+inline bool CompatHasNamedParam(const STMT &stmt, const NAME &name) {
+	return CompatHasNamedParamImpl(stmt, name, CompatHasNamedParamMapAccessor<STMT>());
+}
+
 // --- LogicalType alias --------------------------------------------------------
 // v1.5: void SetAlias(string)                -- mutates in place
 // v2.0: LogicalType WithAlias(string) const  -- returns a copy, never mutating a
@@ -252,42 +283,62 @@ inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::false_type)
 	type.SetAlias(std::move(alias));
 	return type;
 }
-template <class TYPE = LogicalType>
-inline LogicalType CompatWithAlias(TYPE type, string alias) {
-	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<TYPE>());
+// The entry point is CONCRETE, not `template <class TYPE = LogicalType>`: a
+// default template argument is inert because deduction wins, so
+//
+//     CompatWithAlias(LogicalType::VARCHAR, "md")
+//
+// would deduce TYPE = LogicalTypeId -- LogicalType::VARCHAR is a static
+// constexpr LogicalTypeId, not a LogicalType -- and hard-error inside the shim
+// on the PINNED build. A concrete parameter restores the implicit
+// LogicalTypeId -> LogicalType conversion at the call site.
+inline LogicalType CompatWithAlias(LogicalType type, string alias) {
+	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<LogicalType>());
 }
 
 // --- Vector::ToUnifiedFormat ---------------------------------------------------
-// v2.0 dropped the count parameter (the old form is deprecated, not removed).
+// v1.5: ToUnifiedFormat(count, data)  -- the only overload
+// v2.0: ToUnifiedFormat(data)         -- plus the count form kept as [[deprecated]]
+//
+// PROBE FOR THE COUNT-FREE OVERLOAD, not the count-taking one. v2.0 did not
+// remove the count form, it deprecated it, so a probe for the count form is true
+// on BOTH versions and the shim would always take the deprecated path -- silently
+// never reaching the API it exists to call. Probe for what exists ONLY on v2.0.
 // Unused in this extension today; carried for fleet interchangeability.
 template <class T, class = void>
-struct CompatToUnifiedTakesCount : std::false_type {};
+struct CompatToUnifiedWithoutCount : std::false_type {};
 template <class T>
-struct CompatToUnifiedTakesCount<T, decltype(void(std::declval<T &>().ToUnifiedFormat(
-                                        idx_t(0), std::declval<UnifiedVectorFormat &>())))> : std::true_type {};
+struct CompatToUnifiedWithoutCount<T, decltype(void(std::declval<T &>().ToUnifiedFormat(
+                                          std::declval<UnifiedVectorFormat &>())))> : std::true_type {};
 
 template <class VEC>
-inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t count, UnifiedVectorFormat &data, std::true_type) {
-	vec.ToUnifiedFormat(count, data);
+inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t, UnifiedVectorFormat &data, std::true_type) {
+	vec.ToUnifiedFormat(data);
 }
 template <class VEC>
-inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t, UnifiedVectorFormat &data, std::false_type) {
-	vec.ToUnifiedFormat(data);
+inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t count, UnifiedVectorFormat &data, std::false_type) {
+	vec.ToUnifiedFormat(count, data);
 }
 template <class VEC = Vector>
 inline void CompatToUnifiedFormat(VEC &vec, idx_t count, UnifiedVectorFormat &data) {
-	CompatToUnifiedFormatImpl(vec, count, data, CompatToUnifiedTakesCount<VEC>());
+	CompatToUnifiedFormatImpl(vec, count, data, CompatToUnifiedWithoutCount<VEC>());
 }
 
-// --- FlatVector mutable data ---------------------------------------------------
+// --- Direct flat-vector writes ------------------------------------------------
 // v1.5: FlatVector::GetData<T>(vec)         returns T*
+//       FlatVector::Validity(vec)           returns ValidityMask&
 // v2.0: FlatVector::GetData<T>(vec)         returns const T*
 //       FlatVector::GetDataMutable<T>(vec)  returns T*
+//       FlatVector::Validity(vec)           returns const ValidityMask&
+//       FlatVector::ValidityMutable(vec)    returns ValidityMask&
 //
-// CompatGetDataMutable above already covers this repo's ~30 write sites with a
-// const_cast, which is well-defined here (the buffer is not really const) and is
-// left in place rather than churned. This is the fleet-standard spelling that
-// asks for mutability through the real v2.0 accessor.
+// A const_cast off the v2.0 READ accessor is NOT an equivalent -- it compiles and
+// then silently does the wrong thing. On v2.0 the two accessors reach the buffer
+// differently: GetData/Validity go through Vector::GetBufferRef()/Buffer(), while
+// GetDataMutable/ValidityMutable go through Vector::BufferMutable(), which
+// un-shares a copy-on-write buffer first. Writing through the const_cast can
+// therefore scribble into a buffer another vector still shares. These shims call
+// the real mutable accessor wherever it exists.
 template <class T, class = void>
 struct CompatHasFlatGetDataMutable : std::false_type {};
 template <class T>
@@ -305,6 +356,33 @@ inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::false_type) {
 template <class VALUE, class FV = FlatVector>
 inline VALUE *CompatFlatDataMutable(Vector &vec) {
 	return CompatFlatDataMutableImpl<VALUE, FV>(vec, CompatHasFlatGetDataMutable<FV>());
+}
+
+//! Long-standing spelling in this repo (~30 call sites); the fleet-standard name
+//! is CompatFlatDataMutable. Kept as a forwarder so the call sites do not churn.
+template <class T, class FV = FlatVector>
+inline T *CompatGetDataMutable(Vector &vec) {
+	return CompatFlatDataMutable<T, FV>(vec);
+}
+
+template <class T, class = void>
+struct CompatHasFlatValidityMutable : std::false_type {};
+template <class T>
+struct CompatHasFlatValidityMutable<T, decltype(void(T::ValidityMutable(std::declval<Vector &>())))> : std::true_type {
+};
+
+template <class FV>
+inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::true_type) {
+	return FV::ValidityMutable(vec);
+}
+template <class FV>
+inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::false_type) {
+	// Non-const already on v1.5, so this cast is a no-op there.
+	return const_cast<ValidityMask &>(FV::Validity(vec));
+}
+template <class FV = FlatVector>
+inline ValidityMask &CompatGetValidityMutable(Vector &vec) {
+	return CompatFlatValidityMutableImpl<FV>(vec, CompatHasFlatValidityMutable<FV>());
 }
 
 } // namespace duckdb

--- a/src/include/server/tool_handlers.hpp
+++ b/src/include/server/tool_handlers.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "json_utils.hpp"
@@ -176,7 +177,7 @@ private:
 	string result_format;
 
 	string SubstituteParameters(const string &template_sql, const JSONArgumentParser &parser) const;
-	case_insensitive_map_t<BoundParameterData> BuildNamedParameters(const JSONArgumentParser &parser) const;
+	CompatNamedParamMap<BoundParameterData> BuildNamedParameters(const JSONArgumentParser &parser) const;
 };
 
 // Execution SQL tool handler - executes multi-statement SQL templates with prepared binding
@@ -218,7 +219,7 @@ private:
 	vector<unordered_map<string, string>> statement_binding_specs;
 	// Each inner map: param_name -> json_schema_type
 
-	case_insensitive_map_t<BoundParameterData>
+	CompatNamedParamMap<BoundParameterData>
 	BuildNamedParameters(const JSONArgumentParser &parser, const unordered_map<string, string> &binding_spec) const;
 };
 

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -188,7 +188,7 @@ yyjson_mut_val *JSONUtils::ValueToJSON(yyjson_mut_doc *doc, const Value &value) 
 		auto &struct_values = StructValue::GetChildren(value);
 		auto &struct_type = value.type();
 		for (size_t i = 0; i < struct_values.size(); i++) {
-			auto &key = StructType::GetChildName(struct_type, i);
+			auto key = CompatStructFieldName(struct_type, i);
 			yyjson_mut_val *child_val = ValueToJSON(doc, struct_values[i]);
 			yyjson_mut_obj_add(obj, yyjson_mut_strcpy(doc, key.c_str()), child_val);
 		}
@@ -245,10 +245,10 @@ yyjson_mut_val *JSONUtils::QueryResultToJSON(yyjson_mut_doc *doc, const unique_p
 		for (idx_t row = 0; row < chunk->size(); row++) {
 			yyjson_mut_val *json_row = CreateObject(doc);
 
-			for (idx_t col = 0; col < result->names.size(); col++) {
+			for (idx_t col = 0; col < CompatResultNames(*result).size(); col++) {
 				// QueryResult::names is a vector<Identifier> on v2.0; reading a column
 				// name back out as a string is an explicit act there.
-				const string column_name = CompatNameStr(result->names[col]);
+				const string column_name = CompatNameStr(CompatResultNames(*result)[col]);
 				Value cell_value = chunk->GetValue(col, row);
 
 				yyjson_mut_val *json_value = ValueToJSON(doc, cell_value);

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "json_utils.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -245,7 +246,9 @@ yyjson_mut_val *JSONUtils::QueryResultToJSON(yyjson_mut_doc *doc, const unique_p
 			yyjson_mut_val *json_row = CreateObject(doc);
 
 			for (idx_t col = 0; col < result->names.size(); col++) {
-				const string &column_name = result->names[col];
+				// QueryResult::names is a vector<Identifier> on v2.0; reading a column
+				// name back out as a string is an explicit act there.
+				const string column_name = CompatNameStr(result->names[col]);
 				Value cell_value = chunk->GetValue(col, row);
 
 				yyjson_mut_val *json_value = ValueToJSON(doc, cell_value);

--- a/src/protocol/mcp_message.cpp
+++ b/src/protocol/mcp_message.cpp
@@ -1,4 +1,5 @@
 #include "protocol/mcp_message.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/connection.hpp"
@@ -83,7 +84,7 @@ string MCPMessage::ToJSON() const {
 					if (params.type().id() == LogicalTypeId::STRUCT) {
 						auto &struct_values = StructValue::GetChildren(params);
 						for (size_t i = 0; i < struct_values.size(); i++) {
-							auto &key = StructType::GetChildName(params.type(), i);
+							auto key = CompatStructFieldName(params.type(), i);
 							if (key == "uri") {
 								JSONUtils::AddString(doc, params_obj, "uri", struct_values[i].ToString());
 								break;
@@ -98,7 +99,7 @@ string MCPMessage::ToJSON() const {
 						string tool_name;
 						auto &struct_values = StructValue::GetChildren(params);
 						for (size_t i = 0; i < struct_values.size(); i++) {
-							auto &key = StructType::GetChildName(params.type(), i);
+							auto key = CompatStructFieldName(params.type(), i);
 							if (key == "name") {
 								tool_name = struct_values[i].ToString();
 								JSONUtils::AddString(doc, params_obj, "name", tool_name);

--- a/src/protocol/mcp_pagination.cpp
+++ b/src/protocol/mcp_pagination.cpp
@@ -1,4 +1,5 @@
 #include "protocol/mcp_pagination.hpp"
+#include "duckdb_compat.hpp"
 #include "protocol/mcp_message.hpp"
 #ifndef __EMSCRIPTEN__
 #include "protocol/mcp_connection.hpp"
@@ -39,7 +40,7 @@ MCPPaginationResult MCPPaginationResult::FromValue(const Value &value) {
 	auto &struct_children = StructValue::GetChildren(value);
 
 	for (idx_t i = 0; i < struct_children.size(); i++) {
-		auto field_name = StructType::GetChildName(value.type(), i);
+		auto field_name = CompatStructFieldName(value.type(), i);
 		auto &child = struct_children[i];
 
 		if (field_name == "items" && child.type().id() == LogicalTypeId::LIST) {

--- a/src/protocol/mcp_template.cpp
+++ b/src/protocol/mcp_template.cpp
@@ -1,4 +1,5 @@
 #include "protocol/mcp_template.hpp"
+#include "duckdb_compat.hpp"
 #include "protocol/mcp_message.hpp"
 #include "duckdb_mcp_logging.hpp"
 #include "duckdb/common/exception.hpp"
@@ -30,7 +31,7 @@ MCPTemplateArgument MCPTemplateArgument::FromValue(const Value &value) {
 
 	for (idx_t i = 0; i < struct_children.size(); i++) {
 		auto &child = struct_children[i];
-		auto field_name = StructType::GetChildName(value.type(), i);
+		auto field_name = CompatStructFieldName(value.type(), i);
 
 		if (field_name == "name" && child.type() == LogicalType::VARCHAR) {
 			name = child.ToString();
@@ -159,7 +160,7 @@ MCPTemplate MCPTemplate::FromValue(const Value &value) {
 
 	for (idx_t i = 0; i < struct_children.size(); i++) {
 		auto &child = struct_children[i];
-		auto field_name = StructType::GetChildName(value.type(), i);
+		auto field_name = CompatStructFieldName(value.type(), i);
 
 		if (field_name == "name" && child.type() == LogicalType::VARCHAR) {
 			name = child.ToString();
@@ -298,7 +299,7 @@ MCPMessage MCPTemplateManager::HandlePromptsGet(const MCPMessage &request) const
 	} else if (request.params.type().id() == LogicalTypeId::STRUCT) {
 		auto &struct_values = StructValue::GetChildren(request.params);
 		for (size_t i = 0; i < struct_values.size(); i++) {
-			auto &key = StructType::GetChildName(request.params.type(), i);
+			auto key = CompatStructFieldName(request.params.type(), i);
 			if (key == "name") {
 				name = struct_values[i].ToString();
 			} else if (key == "arguments") {

--- a/src/result_formatter.cpp
+++ b/src/result_formatter.cpp
@@ -1,4 +1,5 @@
 #include "result_formatter.hpp"
+#include "duckdb_compat.hpp"
 
 namespace duckdb {
 
@@ -130,7 +131,7 @@ string ResultFormatter::FormatAsJSON(QueryResult &result) {
 			for (idx_t col = 0; col < chunk->ColumnCount(); col++) {
 				if (col > 0)
 					json += ",";
-				json += "\"" + EscapeJsonString(result.names[col]) + "\":";
+				json += "\"" + EscapeJsonString(CompatNameStr(result.names[col])) + "\":";
 				AppendJsonValue(json, chunk->GetValue(col, i), result.types[col]);
 			}
 			json += "}";
@@ -149,7 +150,7 @@ string ResultFormatter::FormatAsJSONL(QueryResult &result) {
 			for (idx_t col = 0; col < chunk->ColumnCount(); col++) {
 				if (col > 0)
 					jsonl += ",";
-				jsonl += "\"" + EscapeJsonString(result.names[col]) + "\":";
+				jsonl += "\"" + EscapeJsonString(CompatNameStr(result.names[col])) + "\":";
 				AppendJsonValue(jsonl, chunk->GetValue(col, i), result.types[col]);
 			}
 			jsonl += "}\n";
@@ -188,7 +189,7 @@ string ResultFormatter::FormatAsCSV(QueryResult &result) {
 	for (idx_t col = 0; col < result.names.size(); col++) {
 		if (col > 0)
 			csv += ",";
-		csv += QuoteCSVField(result.names[col]);
+		csv += QuoteCSVField(CompatNameStr(result.names[col]));
 	}
 	csv += "\n";
 
@@ -230,7 +231,7 @@ string ResultFormatter::FormatAsMarkdown(QueryResult &result) {
 	// Header row
 	md += "|";
 	for (idx_t col = 0; col < num_cols; col++) {
-		md += " " + EscapeMarkdownCell(result.names[col]) + " |";
+		md += " " + EscapeMarkdownCell(CompatNameStr(result.names[col])) + " |";
 	}
 	md += "\n";
 

--- a/src/result_formatter.cpp
+++ b/src/result_formatter.cpp
@@ -131,8 +131,8 @@ string ResultFormatter::FormatAsJSON(QueryResult &result) {
 			for (idx_t col = 0; col < chunk->ColumnCount(); col++) {
 				if (col > 0)
 					json += ",";
-				json += "\"" + EscapeJsonString(CompatNameStr(result.names[col])) + "\":";
-				AppendJsonValue(json, chunk->GetValue(col, i), result.types[col]);
+				json += "\"" + EscapeJsonString(CompatNameStr(CompatResultNames(result)[col])) + "\":";
+				AppendJsonValue(json, chunk->GetValue(col, i), CompatResultTypes(result)[col]);
 			}
 			json += "}";
 		}
@@ -150,8 +150,8 @@ string ResultFormatter::FormatAsJSONL(QueryResult &result) {
 			for (idx_t col = 0; col < chunk->ColumnCount(); col++) {
 				if (col > 0)
 					jsonl += ",";
-				jsonl += "\"" + EscapeJsonString(CompatNameStr(result.names[col])) + "\":";
-				AppendJsonValue(jsonl, chunk->GetValue(col, i), result.types[col]);
+				jsonl += "\"" + EscapeJsonString(CompatNameStr(CompatResultNames(result)[col])) + "\":";
+				AppendJsonValue(jsonl, chunk->GetValue(col, i), CompatResultTypes(result)[col]);
 			}
 			jsonl += "}\n";
 		}
@@ -186,10 +186,10 @@ string ResultFormatter::FormatAsCSV(QueryResult &result) {
 	string csv;
 
 	// Header
-	for (idx_t col = 0; col < result.names.size(); col++) {
+	for (idx_t col = 0; col < CompatResultNames(result).size(); col++) {
 		if (col > 0)
 			csv += ",";
-		csv += QuoteCSVField(CompatNameStr(result.names[col]));
+		csv += QuoteCSVField(CompatNameStr(CompatResultNames(result)[col]));
 	}
 	csv += "\n";
 
@@ -222,7 +222,7 @@ string ResultFormatter::EscapeMarkdownCell(const string &input) {
 
 string ResultFormatter::FormatAsMarkdown(QueryResult &result) {
 	string md;
-	idx_t num_cols = result.names.size();
+	idx_t num_cols = CompatResultNames(result).size();
 
 	if (num_cols == 0) {
 		return "(empty result)";
@@ -231,14 +231,14 @@ string ResultFormatter::FormatAsMarkdown(QueryResult &result) {
 	// Header row
 	md += "|";
 	for (idx_t col = 0; col < num_cols; col++) {
-		md += " " + EscapeMarkdownCell(CompatNameStr(result.names[col])) + " |";
+		md += " " + EscapeMarkdownCell(CompatNameStr(CompatResultNames(result)[col])) + " |";
 	}
 	md += "\n";
 
 	// Separator row with alignment hints
 	md += "|";
 	for (idx_t col = 0; col < num_cols; col++) {
-		bool is_numeric = result.types[col].IsNumeric();
+		bool is_numeric = CompatResultTypes(result)[col].IsNumeric();
 		if (is_numeric) {
 			md += "---:|"; // Right-align numeric columns
 		} else {

--- a/src/server/mcp_server.cpp
+++ b/src/server/mcp_server.cpp
@@ -1,4 +1,5 @@
 #include "server/mcp_server.hpp"
+#include "duckdb_compat.hpp"
 #include "server/resource_providers.hpp"
 #include "server/tool_handlers.hpp"
 #ifndef __EMSCRIPTEN__
@@ -620,7 +621,7 @@ MCPMessage MCPServer::HandleResourcesRead(const MCPMessage &request) {
 		// Params as STRUCT
 		auto &struct_values = StructValue::GetChildren(request.params);
 		for (size_t i = 0; i < struct_values.size(); i++) {
-			auto &key = StructType::GetChildName(request.params.type(), i);
+			auto key = CompatStructFieldName(request.params.type(), i);
 			if (key == "uri") {
 				uri = struct_values[i].ToString();
 				break;
@@ -683,8 +684,8 @@ MCPMessage MCPServer::HandleToolsList(const MCPMessage &request) {
 			JSONUtils::FreeDocument(doc);
 
 			// Create JSON-typed value for the schema
-			Value schema_json_val(schema_str);
-			schema_json_val.Reinterpret(LogicalType::JSON());
+			// v2.0 replaced the mutating Reinterpret with WithType, which returns a copy.
+			Value schema_json_val = CompatWithType(Value(schema_str), LogicalType::JSON());
 
 			Value tool = Value::STRUCT({{"name", Value(name)},
 			                            {"description", Value(handler->GetDescription())},
@@ -728,7 +729,7 @@ MCPMessage MCPServer::HandleToolsCall(const MCPMessage &request) {
 		// Params as STRUCT
 		auto &struct_values = StructValue::GetChildren(request.params);
 		for (size_t i = 0; i < struct_values.size(); i++) {
-			auto &key = StructType::GetChildName(request.params.type(), i);
+			auto key = CompatStructFieldName(request.params.type(), i);
 			if (key == "name") {
 				tool_name = struct_values[i].ToString();
 			} else if (key == "arguments") {

--- a/src/server/mcp_state_table_functions.cpp
+++ b/src/server/mcp_state_table_functions.cpp
@@ -15,7 +15,7 @@ struct MCPToolsData : public GlobalTableFunctionState {
 };
 
 static unique_ptr<FunctionData> MCPToolsBind(ClientContext &context, TableFunctionBindInput &input,
-                                             vector<LogicalType> &return_types, vector<string> &names) {
+                                             vector<LogicalType> &return_types, vector<CompatName> &names) {
 	names.emplace_back("name");
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("description");
@@ -73,7 +73,7 @@ struct MCPResourcesData : public GlobalTableFunctionState {
 };
 
 static unique_ptr<FunctionData> MCPResourcesBind(ClientContext &context, TableFunctionBindInput &input,
-                                                 vector<LogicalType> &return_types, vector<string> &names) {
+                                                 vector<LogicalType> &return_types, vector<CompatName> &names) {
 	names.emplace_back("uri");
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("type");
@@ -163,7 +163,7 @@ static vector<pair<string, string>> ConfigToKVPairs(const MCPServerConfig &confi
 }
 
 static unique_ptr<FunctionData> MCPServerConfigBind(ClientContext &context, TableFunctionBindInput &input,
-                                                    vector<LogicalType> &return_types, vector<string> &names) {
+                                                    vector<LogicalType> &return_types, vector<CompatName> &names) {
 	names.emplace_back("key");
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("value");

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -130,7 +130,7 @@ bool ToolInputSchema::ValidateInput(const Value &input) const {
 	unordered_set<string> provided_fields;
 
 	for (size_t i = 0; i < struct_values.size(); i++) {
-		auto &key = StructType::GetChildName(input.type(), i);
+		auto key = CompatStructFieldName(input.type(), i);
 		provided_fields.insert(key);
 	}
 
@@ -150,7 +150,9 @@ Value ToolInputSchema::ToJSON() const {
 	child_list_t<Value> prop_entries;
 	for (const auto &prop : properties) {
 		// Each property value is a schema object with "type" field
-		prop_entries.push_back(make_pair(prop.first, Value::STRUCT({{"type", prop.second}})));
+		// child_list_t is keyed by Identifier on v2.0 and by string on v1.5, and
+		// prop.first is a runtime string either way.
+		prop_entries.push_back(make_pair(CompatMakeName(prop.first), Value::STRUCT({{"type", prop.second}})));
 	}
 
 	// Create the properties object (empty struct if no properties)
@@ -614,8 +616,8 @@ string ExportToolHandler::ExportToFile(QueryResult &result, const string &format
 			if (col > 0) {
 				create_sql += ", ";
 			}
-			create_sql += KeywordHelper::WriteQuoted(CompatNameStr(result.names[col]), '"') + " " +
-			              result.types[col].ToString();
+			create_sql += KeywordHelper::WriteQuoted(CompatNameStr(CompatResultNames(result)[col]), '"') + " " +
+			              CompatResultTypes(result)[col].ToString();
 		}
 		create_sql += ")";
 

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -666,9 +666,9 @@ SQLToolHandler::SQLToolHandler(const string &name, const string &description, co
       db_instance(db), result_format(result_format) {
 }
 
-case_insensitive_map_t<BoundParameterData>
+CompatNamedParamMap<BoundParameterData>
 SQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser) const {
-	case_insensitive_map_t<BoundParameterData> named_params;
+	CompatNamedParamMap<BoundParameterData> named_params;
 
 	// Build typed values for all schema properties
 	for (const auto &prop : input_schema.properties) {
@@ -677,7 +677,7 @@ SQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser) const {
 
 		if (!parser.HasField(param_name) || parser.IsNull(param_name)) {
 			// Omitted or explicit null → SQL NULL
-			named_params[param_name] = BoundParameterData(Value());
+			named_params[CompatMakeName(param_name)] = BoundParameterData(Value());
 			continue;
 		}
 
@@ -690,7 +690,7 @@ SQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser) const {
 				if (pos != str_val.size()) {
 					throw std::invalid_argument("trailing characters");
 				}
-				named_params[param_name] = BoundParameterData(Value::BIGINT(int_val));
+				named_params[CompatMakeName(param_name)] = BoundParameterData(Value::BIGINT(int_val));
 			} catch (const std::exception &) {
 				throw InvalidInputException("Parameter '" + param_name + "' must be a valid integer, got: " + str_val);
 			}
@@ -701,22 +701,22 @@ SQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser) const {
 				if (pos != str_val.size()) {
 					throw std::invalid_argument("trailing characters");
 				}
-				named_params[param_name] = BoundParameterData(Value::DOUBLE(num_val));
+				named_params[CompatMakeName(param_name)] = BoundParameterData(Value::DOUBLE(num_val));
 			} catch (const std::exception &) {
 				throw InvalidInputException("Parameter '" + param_name + "' must be a valid number, got: " + str_val);
 			}
 		} else if (param_type == "boolean") {
 			if (str_val == "true") {
-				named_params[param_name] = BoundParameterData(Value::BOOLEAN(true));
+				named_params[CompatMakeName(param_name)] = BoundParameterData(Value::BOOLEAN(true));
 			} else if (str_val == "false") {
-				named_params[param_name] = BoundParameterData(Value::BOOLEAN(false));
+				named_params[CompatMakeName(param_name)] = BoundParameterData(Value::BOOLEAN(false));
 			} else {
 				throw InvalidInputException("Parameter '" + param_name +
 				                            "' must be 'true' or 'false', got: " + str_val);
 			}
 		} else {
 			// Default to string (VARCHAR)
-			named_params[param_name] = BoundParameterData(Value(str_val));
+			named_params[CompatMakeName(param_name)] = BoundParameterData(Value(str_val));
 		}
 	}
 
@@ -746,9 +746,9 @@ CallToolResult SQLToolHandler::Execute(const Value &arguments) {
 
 			// Filter to only params this statement expects: a schema may declare
 			// properties the template never references, and DuckDB rejects extras.
-			case_insensitive_map_t<BoundParameterData> filtered_params;
+			CompatNamedParamMap<BoundParameterData> filtered_params;
 			for (auto &entry : named_params) {
-				if (prepared->named_param_map.count(entry.first)) {
+				if (CompatHasNamedParam(*prepared, entry.first)) {
 					filtered_params[entry.first] = std::move(entry.second);
 				}
 			}
@@ -974,17 +974,17 @@ ExecutionSQLToolHandler::ExecutionSQLToolHandler(const string &name, const strin
 	statement_binding_specs = ParseBindingsJson(bindings_json, per_statement_bindings);
 }
 
-case_insensitive_map_t<BoundParameterData>
+CompatNamedParamMap<BoundParameterData>
 ExecutionSQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser,
                                               const unordered_map<string, string> &binding_spec) const {
-	case_insensitive_map_t<BoundParameterData> named_params;
+	CompatNamedParamMap<BoundParameterData> named_params;
 
 	for (const auto &entry : binding_spec) {
 		const string &param_name = entry.first;
 		const string &param_type = entry.second;
 
 		if (!parser.HasField(param_name) || parser.IsNull(param_name)) {
-			named_params[param_name] = BoundParameterData(Value());
+			named_params[CompatMakeName(param_name)] = BoundParameterData(Value());
 			continue;
 		}
 
@@ -997,7 +997,7 @@ ExecutionSQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser,
 				if (pos != str_val.size()) {
 					throw std::invalid_argument("trailing characters");
 				}
-				named_params[param_name] = BoundParameterData(Value::BIGINT(int_val));
+				named_params[CompatMakeName(param_name)] = BoundParameterData(Value::BIGINT(int_val));
 			} catch (const std::exception &) {
 				throw InvalidInputException("Parameter '" + param_name + "' must be a valid integer, got: " + str_val);
 			}
@@ -1008,21 +1008,21 @@ ExecutionSQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser,
 				if (pos != str_val.size()) {
 					throw std::invalid_argument("trailing characters");
 				}
-				named_params[param_name] = BoundParameterData(Value::DOUBLE(num_val));
+				named_params[CompatMakeName(param_name)] = BoundParameterData(Value::DOUBLE(num_val));
 			} catch (const std::exception &) {
 				throw InvalidInputException("Parameter '" + param_name + "' must be a valid number, got: " + str_val);
 			}
 		} else if (param_type == "boolean") {
 			if (str_val == "true") {
-				named_params[param_name] = BoundParameterData(Value::BOOLEAN(true));
+				named_params[CompatMakeName(param_name)] = BoundParameterData(Value::BOOLEAN(true));
 			} else if (str_val == "false") {
-				named_params[param_name] = BoundParameterData(Value::BOOLEAN(false));
+				named_params[CompatMakeName(param_name)] = BoundParameterData(Value::BOOLEAN(false));
 			} else {
 				throw InvalidInputException("Parameter '" + param_name +
 				                            "' must be 'true' or 'false', got: " + str_val);
 			}
 		} else {
-			named_params[param_name] = BoundParameterData(Value(str_val));
+			named_params[CompatMakeName(param_name)] = BoundParameterData(Value(str_val));
 		}
 	}
 
@@ -1074,9 +1074,9 @@ CallToolResult ExecutionSQLToolHandler::Execute(const Value &arguments) {
 			auto named_params = BuildNamedParameters(parser, binding_spec);
 
 			// Filter to only params this statement expects (object binding may include extras)
-			case_insensitive_map_t<BoundParameterData> filtered_params;
+			CompatNamedParamMap<BoundParameterData> filtered_params;
 			for (auto &entry : named_params) {
-				if (prepared->named_param_map.count(entry.first)) {
+				if (CompatHasNamedParam(*prepared, entry.first)) {
 					filtered_params[entry.first] = std::move(entry.second);
 				}
 			}

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -614,7 +614,8 @@ string ExportToolHandler::ExportToFile(QueryResult &result, const string &format
 			if (col > 0) {
 				create_sql += ", ";
 			}
-			create_sql += KeywordHelper::WriteQuoted(CompatNameStr(result.names[col]), '"') + " " + result.types[col].ToString();
+			create_sql += KeywordHelper::WriteQuoted(CompatNameStr(result.names[col]), '"') + " " +
+			              result.types[col].ToString();
 		}
 		create_sql += ")";
 

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -669,8 +669,7 @@ SQLToolHandler::SQLToolHandler(const string &name, const string &description, co
       db_instance(db), result_format(result_format) {
 }
 
-CompatNamedParamMap<BoundParameterData>
-SQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser) const {
+CompatNamedParamMap<BoundParameterData> SQLToolHandler::BuildNamedParameters(const JSONArgumentParser &parser) const {
 	CompatNamedParamMap<BoundParameterData> named_params;
 
 	// Build typed values for all schema properties

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/appender.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb_compat.hpp"
 #include "json_utils.hpp"
 #include "result_formatter.hpp"
 #include <cctype>
@@ -613,7 +614,7 @@ string ExportToolHandler::ExportToFile(QueryResult &result, const string &format
 			if (col > 0) {
 				create_sql += ", ";
 			}
-			create_sql += KeywordHelper::WriteQuoted(result.names[col], '"') + " " + result.types[col].ToString();
+			create_sql += KeywordHelper::WriteQuoted(CompatNameStr(result.names[col]), '"') + " " + result.types[col].ToString();
 		}
 		create_sql += ")";
 
@@ -627,7 +628,9 @@ string ExportToolHandler::ExportToFile(QueryResult &result, const string &format
 		auto &collection = materialized.Collection();
 
 		if (collection.Count() > 0) {
-			Appender appender(conn, temp_table);
+			// Appender takes an Identifier on v2.0 and a string on v1.5; temp_table is a
+			// runtime string, so promoting it is explicit.
+			Appender appender(conn, CompatMakeName(temp_table));
 			for (auto &chunk : collection.Chunks()) {
 				appender.AppendDataChunk(chunk);
 			}

--- a/test/sql/mcp_scalar_error_contract.test
+++ b/test/sql/mcp_scalar_error_contract.test
@@ -1,0 +1,185 @@
+# name: test/sql/mcp_scalar_error_contract.test
+# description: MCP scalar functions report failures as VALUES, never as thrown errors
+# group: [sql]
+
+# WHY THIS TEST EXISTS (DuckDB v2.0 change class 13).
+#
+# Every scalar function in this extension wraps its work in
+# `catch (const std::exception &e)` and turns the failure into a value in the
+# result vector rather than throwing. That is a deliberate design, and it is also
+# the reason none of them is registered as CAN_THROW in RegisterScalar
+# (src/duckdb_mcp_extension.cpp): a function that cannot let an INVALID_INPUT /
+# OUT_OF_RANGE / CONVERSION exception escape does not need SetFallible(), and
+# declaring one that does not need it makes the planner needlessly conservative
+# around it on the pinned v1.5 line as well as on v2.0.
+#
+# That reasoning is only as good as the invariant it rests on, and the invariant
+# is invisible: deleting a try/catch, or hoisting a throwing call above one,
+# compiles fine and breaks nothing that any other test looks at. On DuckDB v2.0
+# the symptom would be a user-facing
+#
+#   INTERNAL Error: Scalar function "..." threw an execution error, but the
+#   function is not marked as fallible - the function must call SetFallible().
+#
+# So each assertion below is `query`, never `statement error`: the whole point is
+# that the statement SUCCEEDS and the error arrives as a string. If one of these
+# starts raising instead, this test fails on BOTH DuckDB lines, at the commit
+# that broke it, rather than silently on someone's v2.0 build.
+#
+# If you make one of these functions genuinely throw, that is allowed -- change
+# its verdict to ScalarErrors::CAN_THROW and change the assertion here to match.
+
+# The ::VARCHAR casts are load-bearing: several of these return LogicalType::JSON(),
+# and the unittest binary does not have the json extension loaded, so JSON has no
+# implicit cast to VARCHAR there and `LIKE` fails to bind. The cast keeps the
+# assertion about the VALUE rather than about which extensions happen to be loaded.
+
+require duckdb_mcp
+
+statement ok
+LOAD duckdb_mcp;
+
+# ---- Client-side functions against a server that was never attached ----
+# registry.GetConnection() returns null, the body throws InvalidInputException
+# (an EXECUTION-class type -- exactly the kind v2.0 polices), and the handler
+# converts it to a string. Nothing escapes.
+
+query I
+SELECT mcp_get_resource('no_such_server', 'file:///x')::VARCHAR LIKE 'ERROR:%not attached%';
+----
+true
+
+query I
+SELECT mcp_list_resources('no_such_server')::VARCHAR LIKE 'ERROR:%not attached%';
+----
+true
+
+query I
+SELECT mcp_list_tools('no_such_server')::VARCHAR LIKE 'ERROR:%not attached%';
+----
+true
+
+query I
+SELECT mcp_list_prompts('no_such_server')::VARCHAR LIKE 'ERROR:%not attached%';
+----
+true
+
+query I
+SELECT mcp_call_tool('no_such_server', 'some_tool', '{}')::VARCHAR LIKE 'ERROR:%not attached%';
+----
+true
+
+query I
+SELECT mcp_get_prompt('no_such_server', 'some_prompt', '{}')::VARCHAR LIKE 'ERROR:%not attached%';
+----
+true
+
+# The cursor overloads are separate implementations with their own handlers, and
+# they format the swallowed error as a JSON object rather than an ERROR: string.
+query I
+SELECT mcp_list_resources('no_such_server', 'cursor123')::VARCHAR LIKE '%not attached%';
+----
+true
+
+query I
+SELECT mcp_list_tools('no_such_server', 'cursor123')::VARCHAR LIKE '%not attached%';
+----
+true
+
+query I
+SELECT mcp_list_prompts('no_such_server', 'cursor123')::VARCHAR LIKE '%not attached%';
+----
+true
+
+query I
+SELECT mcp_reconnect_server('no_such_server') LIKE 'ERROR:%';
+----
+true
+
+# ---- Prompt templates: an unknown name is reported, not raised ----
+
+query I
+SELECT mcp_render_prompt_template('no_such_template', '{}') LIKE 'Error:%';
+----
+true
+
+# ---- An InvalidInputException raised internally must not escape ----
+# This is the sharpest assertion in the file for change class 13. Parsing
+# '{"bogus":' raises an InvalidInputException -- ExceptionType::INVALID_INPUT,
+# one of the exact three types Exception::IsExecutionError() recognises -- deep
+# inside the request handler. The handler catches it and renders it as a JSON-RPC
+# error object. If that catch ever went away, this is the function v2.0 would
+# rewrite into "not marked as fallible", and this assertion is what notices.
+
+query I
+SELECT mcp_server_test('{"bogus":') LIKE '%Failed to parse JSON%';
+----
+true
+
+# ---- Publishing with an unusable argument ----
+# The format string is validated inside the try, so an invalid one comes back as
+# a value rather than as a raised error.
+
+query I
+SELECT mcp_publish_tool(
+    'contract_bad_format',
+    'Should be reported, not raised',
+    'SELECT 1',
+    '{}',
+    '[]',
+    'not_a_real_format'
+) LIKE 'ERROR:%Unsupported format%';
+----
+true
+
+query I
+SELECT mcp_publish_table('no_such_table_xyz', 'mcp://x', 'json') LIKE 'ERROR:%not found%';
+----
+true
+
+query I
+SELECT mcp_server_health('no_such_server') LIKE 'ERROR:%';
+----
+true
+
+# ---- Server lifecycle functions return a status STRUCT, never an exception ----
+# These are the four functions with no try in the body at all; their work is done
+# inside MCPServerStartCore / MCPServerStopCore, which are wrapped end to end.
+
+query I
+SELECT (mcp_server_start('no_such_transport')).success;
+----
+false
+
+query I
+SELECT (mcp_server_start('no_such_transport', '{}')).success;
+----
+false
+
+query I
+SELECT (mcp_server_stop()).success IS NOT NULL;
+----
+true
+
+query I
+SELECT (mcp_server_stop(true)).success;
+----
+true
+
+query I
+SELECT (mcp_server_status()).success IS NOT NULL;
+----
+true
+
+# ---- Multi-row: the handlers live inside the per-row loop ----
+# A single bad row must not take out the whole vector, and the good rows must
+# still be produced. This is the shape that would break first if a try were
+# hoisted out of the loop.
+
+query I
+SELECT count(*) FROM (
+    SELECT mcp_get_resource(s, 'file:///x')::VARCHAR AS r
+    FROM (VALUES ('no_such_server'), ('also_missing'), ('third_missing')) t(s)
+) WHERE r LIKE 'ERROR:%';
+----
+3

--- a/test/sql/mcp_state_tables.test
+++ b/test/sql/mcp_state_tables.test
@@ -114,6 +114,40 @@ SELECT uri, status FROM mcp_resources() ORDER BY uri;
 data://products	pending
 data://readme	pending
 
+# Per-vector size tracking (DuckDB v2.0 change class 18).
+#
+# These scans fill their output with DataChunk::SetValue, which writes AT AN
+# INDEX and does not advance a vector's size. On v2.0 DataChunk::SetCardinality
+# no longer sizes the child vectors either, so a scan that used it directly would
+# leave every column at size 0. CompatSetOutputCardinality forwards to
+# SetChildCardinality, which is what actually sizes them.
+#
+# The failure that shim prevents is SILENT, and this is the only assertion in the
+# suite that can see it. Readers that go through the CHUNK count -- count(*), the
+# printer, every other query in this file -- stay correct, so nothing else would
+# notice. IS NULL iterates the VECTOR's size, finds zero rows, writes nothing,
+# and the result buffer keeps its default `false`. The bug's signature is a
+# column that PRINTS as NULL while `IS NULL` on it returns false, in the same
+# result set.
+#
+# Two things about the shape of this query are load-bearing:
+#
+#   NO WHERE CLAUSE. A pushed-down filter routes through SelectFilteredRows,
+#   whose Reference/Slice sizes the vectors correctly on the way out -- so the
+#   filtered form passes with the bug still present. (The `WHERE name = ...`
+#   check on sql_template further up this file is exactly that shape, and guards
+#   nothing.) `rowsort` orders the rows client-side so the SQL stays a bare scan.
+#
+#   BOTH DIRECTIONS OF NULLNESS, ALONGSIDE A VALUE IN THE SAME ROW. Asserting
+#   only `IS NULL` -> true would be indistinguishable from a stuck `false` on the
+#   rows where the true answer happens to be false. Row 1 has NULL
+#   description/mime_type with a non-NULL format; row 2 has the reverse.
+query TIITIT rowsort
+SELECT uri, description IS NULL, mime_type IS NULL, source, format IS NULL, status FROM mcp_resources();
+----
+data://products	true	true	test_products	false	pending
+data://readme	false	false	Hello World	true	pending
+
 # =============================================================================
 # SECTION 4: After server start — tools become active
 # =============================================================================


### PR DESCRIPTION
Makes duckdb_mcp build and run against **both** the pinned v1.5 line and DuckDB main (the v2.0 / cyanoptera line), which is the last item blocking a release.

## Where this started

The advisory canary on `main` did not compile. Its reported errors were in `json_utils.cpp` and `result_formatter.cpp` (change class 17 — `BaseQueryResult::names`/`types` went private *and* changed element type). That list was incomplete, because the build stopped before reaching the rest: the three table-function bind signatures in `mcp_state_table_functions.cpp` are class 2, and `tool_handlers.cpp` had both class 17 and the prepared-statement named-parameter rekey.

## Classes hit, and how each was resolved

| # | Change | Resolution |
|---|---|---|
| 2 | bind names `string` → `Identifier` | `CompatName`, derived from `table_function_bind_t`'s 4th parameter; 3 bind signatures converted |
| 3 | `FlatVector::GetData` is read-only | `CompatFlatDataMutable` calls the real `GetDataMutable` where it exists |
| 6 | fields → accessors | property setters call the accessors, present on both lines |
| 13 | fallible scalar functions | audited all 32; see below |
| 14 | `FlatVector::Validity` const split | `CompatFlatValidityMutable` |
| 16 | `CreateInfo`/`DropInfo` → private `QualifiedName` | `CompatEntryName` / `CompatSchemaName` / `CompatSetSchemaName` |
| 17 | result names/types private + `Identifier` | `CompatResultNames` / `CompatResultTypes` |
| 18 | `SetCardinality` vs `SetChildCardinality` | shim already existed and is bypassed nowhere; **regression test added** |
| 9 | per-vector headers moved | included where present |
| — | `Value::Reinterpret` → `WithType`, STRUCT field names, prepared named-parameter maps | shimmed |

Classes **4, 7, 8, 10, 11, 12, 15, 19, 20, 21 do not apply** to this extension, each checked rather than assumed:

- **19 (single-arrow lambdas)** — `grep -rnE '(list_transform|list_filter|list_reduce|apply|filter|reduce)\(.*->' test/ src/` is empty. No shipped SQL or `DefaultMacro` body contains one.
- **20/21 (COPY options)** — the extension registers no COPY function, and no test pins an option-name string. The one test comment mentioning `unrecognized option` expects only `MCP`.
- **5** — no `ScalarFunctionSet`; the `PragmaFunctionSet`s are not `BaseScalarFunction` and are never mutated after insertion.

## Detect features, not versions — and not proxy headers

The `#if __has_include("duckdb/common/vector/list_vector.hpp")` dispatch is gone. A header's presence was standing in for "`DataChunk` has `SetChildCardinality`" and for "fields moved behind accessors" simultaneously — precisely the coupling that makes a backport flip every shim in the file at once, which is not hypothetical: `identifier.hpp` was backported to `v1.5-variegata` **without** the `table_function_bind_t` signature change. `__has_include` now survives only where it belongs, deciding whether a header can be included.

`CompatName` derives from `table_function_bind_t`'s fourth parameter — the bind-name out-parameter itself. Three separate declarations flipped `string` → `Identifier` in v2.0 (the bind callback's names, `TableFunctionBindInput::input_table_names`, and `child_list_t`'s key, which is STRUCT field names); they agree today but are independent. Result column names (class 17) are a fourth, so `CompatResultNames` reads its container type off the `QueryResult` rather than reusing `CompatName`.

Each probe is pinned. Compiled against both lines, `static_assert` confirms every probe resolves to the **old** API on the pin and the **new** API on main — discrimination, not merely compilation.

## Class 13: audited, not blanket-marked

An earlier revision marked all 32 scalar functions fallible on the theory that auditing "would buy nothing". Measuring it changed the answer.

Enforcement runs through `Exception::IsExecutionError`, which recognises exactly three types — `INVALID_INPUT`, `OUT_OF_RANGE`, `CONVERSION`. Everything else (`BinderException`, `IOException`, `InternalException`, `OutOfMemoryException`) takes `ThrowNonFallibleFunctionError`'s `throw;` branch and propagates unchanged. So marking for those buys nothing and costs a real pessimisation on the **pinned** line, where `FunctionErrors` already feeds `Expression::CanThrow()` and gates conjunct reordering, filter pushdown and dictionary-expression caching.

All 32 were audited. Every one wraps its DuckDB-calling and MCP-calling work in `catch (const std::exception &e)` and converts the failure into a value in the result vector — a deliberate design, not an accident. Not one lets an execution-class exception escape. The only escapes from the hoisted preamble are `ExpressionState::GetContext()` (`BinderException`), `Vector::GetValue` on an unimplemented vector type (`InternalException`), and allocation inside a catch handler — none of them execution errors.

**So none is marked**, and `RegisterScalar` now requires a `ScalarErrors` verdict at every registration site, so a new scalar function cannot be added without walking past the reasoning.

## Two tests that pin invariants nothing else could see

**`mcp_scalar_error_contract.test`** locks the swallow contract the class-13 verdict rests on — otherwise invisible, since deleting a `try`/`catch` compiles fine and breaks nothing else in the suite. Verified in **both directions**: it passes as written, and rewriting `mcp_server_test`'s handler to `throw;` makes it fail at that assertion with `Invalid Input Error: Failed to parse JSON` — the exact `INVALID_INPUT` escape v2.0 would rewrite into "the function is not marked as fallible".

**`mcp_state_tables.test`** gains an *unfiltered* class-18 scan. The file's existing `IS NOT NULL` check sits behind a `WHERE`, which guards nothing: a pushed-down filter routes through `SelectFilteredRows`, whose `Reference`/`Slice` sizes the vectors correctly on the way out. The new assertion has no `WHERE` (`rowsort` orders client-side) and checks both directions of nullness alongside a real value in the same row, so a stuck `false` cannot pass.

## Verification

- **Pinned DuckDB v1.5.4-154-gb155d6f63c**: build green, 35 test files, **1189 assertions, all passing**.
- **DuckDB main @154c2c8d5f**: all **26 TUs** compiled with `-fsyntax-only` locally against a checkout of main — no errors. This is a local pre-check, not a substitute for the canary's Test step.
- No new `clang-format` drift. Two files drift on `main` already; those hunks are left alone rather than mixed into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz