### PR TITLE
stdio: take fd 1 away from the process so stray writes cannot corrupt the JSON-RPC stream

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -97,3 +97,11 @@ jobs:
         run: |
           chmod +x test/http/test_http_transport.sh
           ./test/http/test_http_transport.sh
+
+      # Guards the stdio protocol stream against stray writes to fd 1 (issue #74).
+      # The failure this catches is silent — a successful response is dropped by the
+      # peer rather than an error being raised — so it has to be asserted explicitly.
+      - name: Run stdio stdout hygiene tests
+        run: |
+          chmod +x test/stdio/test_stdio_stdout_hygiene.sh
+          ./test/stdio/test_stdio_stdout_hygiene.sh

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,40 @@ All notable changes to the DuckDB MCP Extension.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **stdio transport: stdout now carries nothing but JSON-RPC** (#74). JSON-RPC over
+  stdio requires file descriptor 1 to hold framed protocol messages and nothing else,
+  but several writers reach it without going through the transport. The DuckDB CLI
+  installs its own log storage globally and prints every `DUCKDB_LOG_WARNING` to
+  stdout wrapped in ANSI colour codes, so a warning raised *inside* a query the client
+  triggered via `tools/call` — a deprecated `->` lambda, an extension warning on an
+  unreadable file — landed mid-stream and its trailing `\033[00m` reset prefixed the
+  next response line. A strict client then dropped a *successful* response, silently.
+  `SET logging_storage='stdout'`, the terminal progress bar and any third-party
+  `printf` did the same.
+
+  Rather than filter an open-ended set of writers, the stdio transport now takes the
+  descriptor away from them: on connect it duplicates stdout to a private handle that
+  only the transport writes to, and points fd 1 at stderr for the duration of the
+  session. Stray output is diverted, not suppressed — it still reaches stderr, which
+  is the channel a supervisor collects. stdout is restored when the session ends.
+
+- MCP console logging (`SET mcp_console_logging = true`) now writes every level to
+  stderr. Non-error levels went to stdout, which corrupted the protocol stream of a
+  running stdio server. The option has always been documented as
+  "Enable MCP logging to console/stderr".
+
+### Documentation
+
+- Server usage guide: document stdout ownership under the stdio transport, and how to
+  silence the CLI's per-statement `Success` rendering during the init-script setup
+  phase, which happens before the server starts and is outside the transport's reach.
+
+---
+
 ## v2.1.2
 
 ### Fixed

--- a/docs/guides/server-usage.md
+++ b/docs/guides/server-usage.md
@@ -24,6 +24,31 @@ PRAGMA mcp_server_start('stdio');
 
 The server blocks and waits for requests on stdin, responding on stdout.
 
+!!! note "stdout belongs to the protocol"
+    While a stdio server is running, the extension takes exclusive ownership of the
+    process's stdout: it keeps a private handle for the JSON-RPC stream and points
+    file descriptor 1 at **stderr**. Anything else that would have written to stdout —
+    a DuckDB warning surfaced by the CLI's logger, `SET logging_storage='stdout'`, a
+    progress bar, a `printf` from another extension — is diverted to stderr instead of
+    landing inside a protocol frame. Nothing is suppressed, so a supervisor or
+    container still collects it; it just cannot desynchronise the channel. stdout is
+    restored when the session ends.
+
+    That covers the *running* server. Statements that execute **before**
+    `mcp_server_start` still render through the CLI, which prints a `Success` block per
+    statement on stdout — a strict client reading from process start will choke on
+    those. Silence the setup phase in your init script:
+
+    ```sql
+    .mode list
+    .headers off
+    LOAD duckdb_mcp;
+    PRAGMA mcp_publish_tool(...);
+    PRAGMA mcp_server_start('stdio');
+    ```
+
+    Prefer `PRAGMA` over `SELECT` for the publishing calls for the same reason.
+
 ### Server with Configuration
 
 ```sql

--- a/src/duckdb_mcp_logging.cpp
+++ b/src/duckdb_mcp_logging.cpp
@@ -77,13 +77,16 @@ void MCPLogger::LogMessage(MCPLogLevel level, const string &component, const str
 
 	string formatted_message = FormatLogEntry(level, component, message);
 
-	// Write to console if enabled
+	// Write to console if enabled.
+	//
+	// Diagnostics go to stderr at EVERY level, never stdout. When a stdio MCP server is
+	// running, stdout carries the JSON-RPC frame stream and a diagnostic line written
+	// there desynchronises the channel for the peer (issue #74). The stdio transport
+	// additionally takes fd 1 away for the duration of a session, but this logger must
+	// not be aiming at stdout in the first place: the `mcp_console_logging` option has
+	// always been documented as "Enable MCP logging to console/stderr".
 	if (console_logging) {
-		if (level >= MCPLogLevel::ERROR) {
-			std::cerr << formatted_message << std::endl;
-		} else {
-			std::cout << formatted_message << std::endl;
-		}
+		std::cerr << formatted_message << std::endl;
 	}
 
 #ifndef __EMSCRIPTEN__

--- a/src/include/server/stdio_server_transport.hpp
+++ b/src/include/server/stdio_server_transport.hpp
@@ -8,8 +8,64 @@ namespace duckdb {
 
 #ifndef __EMSCRIPTEN__
 
+//! Exclusive owner of the process's real stdout for the lifetime of a stdio MCP session.
+//!
+//! JSON-RPC over stdio requires fd 1 to carry framed protocol messages and NOTHING else.
+//! A DuckDB process, however, has several writers that reach fd 1 without going through
+//! the transport, and any one of them desynchronises the channel for every connected
+//! client:
+//!
+//!   * The DuckDB CLI shell installs its own log storage as the global one
+//!     (`RegisterShellLogger` in tools/shell/shell.cpp) at LOG_WARNING level, and
+//!     `ShellLogStorage::WriteLogEntry` prints each entry to STDOUT wrapped in ANSI colour
+//!     codes. So every `DUCKDB_LOG_WARNING` raised anywhere in DuckDB or in any loaded
+//!     extension — including from inside a query the MCP client itself triggered via
+//!     `tools/call` — lands mid-stream, and its trailing `\033[00m` reset prefixes the
+//!     next response line. See issue #74.
+//!   * `SET logging_storage='stdout'` installs DuckDB's own StdOutLogStorage, which
+//!     writes log rows via `Printer::RawPrint(OutputStream::STREAM_STDOUT, ...)`.
+//!   * The terminal progress bar writes to STREAM_STDOUT.
+//!   * Any third-party extension that printf()s.
+//!
+//! Filtering individual message sources cannot work: the set of writers is open-ended and
+//! grows with every extension the user loads. So instead of policing the writers, this
+//! class takes the descriptor away from them. `Acquire()` duplicates fd 1 to a private
+//! descriptor that only the transport holds, then points fd 1 at fd 2. From that moment
+//! every stray write — whoever makes it, through whatever API — goes to stderr, which is
+//! the channel a supervisor or container collects anyway, and nothing is silently lost.
+//! `Release()` puts fd 1 back the way it was.
+class ProtocolStdout {
+public:
+	ProtocolStdout();
+	~ProtocolStdout();
+
+	// Non-copyable: this object owns a descriptor and a process-global side effect.
+	ProtocolStdout(const ProtocolStdout &) = delete;
+	ProtocolStdout &operator=(const ProtocolStdout &) = delete;
+
+	//! Take the real stdout private and repoint fd 1 at stderr.
+	//! Returns false if the descriptor could not be duplicated or redirected, in which case
+	//! nothing has changed and writes fall back to the process stdout (the pre-fix behaviour,
+	//! which is degraded but still functional).
+	bool Acquire();
+	//! Restore fd 1 to whatever it referred to before Acquire(). Idempotent.
+	void Release();
+	bool IsAcquired() const {
+		return acquired;
+	}
+	//! Write raw bytes to the protocol channel. Handles short writes and EINTR.
+	//! Returns false if the bytes could not all be written.
+	bool Write(const char *data, size_t size);
+
+private:
+	//! Private duplicate of the original fd 1, or -1 when not acquired.
+	int protocol_fd;
+	bool acquired;
+};
+
 //! Server-side stdio transport for MCP communication
-//! Uses std::cin/std::cout for proper blocking I/O without the poll/iostream mixing issues
+//! Reads requests from stdin and writes responses to the process's real stdout, which it
+//! takes exclusive ownership of via ProtocolStdout for the lifetime of the connection.
 class FdServerTransport : public MCPTransport {
 public:
 	//! Create transport using stdin/stdout
@@ -30,6 +86,8 @@ public:
 private:
 	bool connected;
 	mutable mutex io_mutex;
+	//! Guards fd 1 while the session is connected.
+	ProtocolStdout protocol_stdout;
 };
 
 #endif // !__EMSCRIPTEN__

--- a/src/server/stdio_server_transport.cpp
+++ b/src/server/stdio_server_transport.cpp
@@ -2,9 +2,122 @@
 #include "protocol/mcp_message.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb_mcp_logging.hpp"
+#include <cerrno>
+#include <cstdio>
 #include <iostream>
 
+#ifdef _WIN32
+#include <io.h>
+#define MCP_DUP       _dup
+#define MCP_DUP2      _dup2
+#define MCP_CLOSE     _close
+#define MCP_STDOUT_FD _fileno(stdout)
+#define MCP_STDERR_FD _fileno(stderr)
+#else
+#include <unistd.h>
+#define MCP_DUP       dup
+#define MCP_DUP2      dup2
+#define MCP_CLOSE     close
+#define MCP_STDOUT_FD STDOUT_FILENO
+#define MCP_STDERR_FD STDERR_FILENO
+#endif
+
 namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// ProtocolStdout
+//===--------------------------------------------------------------------===//
+
+static int64_t WriteFd(int fd, const char *data, size_t size) {
+#ifdef _WIN32
+	return static_cast<int64_t>(_write(fd, data, static_cast<unsigned int>(size)));
+#else
+	return static_cast<int64_t>(::write(fd, data, size));
+#endif
+}
+
+ProtocolStdout::ProtocolStdout() : protocol_fd(-1), acquired(false) {
+}
+
+ProtocolStdout::~ProtocolStdout() {
+	Release();
+}
+
+bool ProtocolStdout::Acquire() {
+	if (acquired) {
+		return true;
+	}
+
+	// Anything the host process has already buffered for the real stdout must be drained
+	// BEFORE the descriptor moves — otherwise it would be flushed to stderr later and
+	// appear to have vanished. The CLI shell in particular buffers its own output.
+	std::cout.flush();
+	fflush(stdout);
+
+	int dup_fd = MCP_DUP(MCP_STDOUT_FD);
+	if (dup_fd < 0) {
+		// Could not duplicate stdout; leave the process alone and fall back to writing
+		// straight to fd 1 (the pre-fix behaviour).
+		return false;
+	}
+	if (MCP_DUP2(MCP_STDERR_FD, MCP_STDOUT_FD) < 0) {
+		MCP_CLOSE(dup_fd);
+		return false;
+	}
+
+	protocol_fd = dup_fd;
+	acquired = true;
+	return true;
+}
+
+void ProtocolStdout::Release() {
+	if (!acquired) {
+		return;
+	}
+	acquired = false;
+
+	// Drain whatever was written to the stderr-backed fd 1 while we held it, so it is
+	// delivered to stderr rather than to the restored stdout.
+	std::cout.flush();
+	fflush(stdout);
+
+	MCP_DUP2(protocol_fd, MCP_STDOUT_FD);
+	MCP_CLOSE(protocol_fd);
+	protocol_fd = -1;
+}
+
+bool ProtocolStdout::Write(const char *data, size_t size) {
+	if (!acquired) {
+		// Degraded path: we never got the descriptor, so fd 1 is still shared with
+		// whatever else the process writes through stdio buffers. Drain those first so
+		// this frame is not interleaved into the middle of a buffered line.
+		std::cout.flush();
+		fflush(stdout);
+	}
+	const int fd = acquired ? protocol_fd : MCP_STDOUT_FD;
+	size_t written = 0;
+	while (written < size) {
+		auto n = WriteFd(fd, data + written, size - written);
+		if (n < 0) {
+#ifndef _WIN32
+			if (errno == EINTR) {
+				// Interrupted before any byte was transferred - retry.
+				continue;
+			}
+#endif
+			return false;
+		}
+		if (n == 0) {
+			return false;
+		}
+		written += static_cast<size_t>(n);
+	}
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// FdServerTransport
+//===--------------------------------------------------------------------===//
 
 FdServerTransport::FdServerTransport() : connected(false) {
 }
@@ -20,6 +133,14 @@ bool FdServerTransport::Connect() {
 		return true;
 	}
 
+	// Take exclusive ownership of the real stdout for the duration of the session, so that
+	// only framed JSON-RPC reaches the peer (issue #74). A failure here is not fatal: the
+	// transport still works, it is just no longer protected from stray writes.
+	if (!protocol_stdout.Acquire()) {
+		MCP_LOG_WARN("stdio", "Could not take exclusive ownership of stdout; a stray write by "
+		                      "DuckDB or another extension may corrupt the JSON-RPC stream");
+	}
+
 	connected = true;
 	return true;
 }
@@ -27,6 +148,7 @@ bool FdServerTransport::Connect() {
 void FdServerTransport::Disconnect() {
 	lock_guard<mutex> lock(io_mutex);
 	connected = false;
+	protocol_stdout.Release();
 }
 
 bool FdServerTransport::IsConnected() const {
@@ -44,11 +166,18 @@ void FdServerTransport::Send(const MCPMessage &message) {
 	try {
 		string json = message.ToJSON();
 		MCP_LOG_DEBUG("stdio", "Sending response: %s", json.substr(0, 100).c_str());
-		// Write directly to stdout and flush immediately
-		std::cout << json << std::endl;
-		std::cout.flush();
+		// Write the framed message to the protocol channel in a single call. Note this
+		// deliberately does NOT go through std::cout: while the session is connected,
+		// fd 1 points at stderr and std::cout is where the stray writes we are protecting
+		// against end up.
+		json += "\n";
+		if (!protocol_stdout.Write(json.c_str(), json.size())) {
+			throw IOException("Failed to write message to stdout");
+		}
 		MCP_LOG_DEBUG("stdio", "Response sent and flushed");
 
+	} catch (const IOException &) {
+		throw;
 	} catch (const std::exception &e) {
 		MCP_LOG_ERROR("stdio", "Failed to send message: %s", e.what());
 		throw IOException("Failed to send message: " + string(e.what()));

--- a/test/stdio/test_stdio_stdout_hygiene.sh
+++ b/test/stdio/test_stdio_stdout_hygiene.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+# Regression test for issue #74 — stdout hygiene of the stdio transport.
+#
+# JSON-RPC over stdio requires fd 1 to carry framed protocol messages and NOTHING
+# else. A DuckDB process has several writers that reach fd 1 without going through
+# the transport:
+#
+#   1. The DuckDB CLI shell installs its own log storage as the global one and
+#      prints every DUCKDB_LOG_WARNING to STDOUT wrapped in ANSI colour codes. A
+#      warning raised while a tools/call is executing lands *inside* the protocol
+#      stream and its trailing \033[00m reset prefixes the next response line, so
+#      the response no longer starts with '{' and a strict client drops it.
+#   2. `SET logging_storage='stdout'` installs DuckDB's own StdOutLogStorage,
+#      which writes log rows straight to STREAM_STDOUT.
+#   3. duckdb_mcp's own console logger (`SET mcp_console_logging=true`).
+#
+# The failure is silent: a *successful* response vanishes rather than an error
+# being reported. So this test does not check that the happy path works — it
+# deliberately provokes each stray writer and then asserts that stdout still
+# contains nothing but well-formed JSON-RPC.
+#
+# IMPORTANT: each provocation is paired with a liveness check that the stray
+# writer actually fired. Without that, the test would pass vacuously the day
+# DuckDB stops emitting the warning we use as a trigger.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Both are overridable so the same script can be pointed at another build tree
+# (useful when confirming that this test does fail against a build without the fix).
+DUCKDB="${DUCKDB:-${PROJECT_DIR}/build/release/duckdb}"
+EXTENSION="${EXTENSION:-${PROJECT_DIR}/build/release/extension/duckdb_mcp/duckdb_mcp.duckdb_extension}"
+
+# Fall back to debug build if release isn't available
+if [ ! -f "$DUCKDB" ]; then
+    DUCKDB="${PROJECT_DIR}/build/debug/duckdb"
+    EXTENSION="${PROJECT_DIR}/build/debug/extension/duckdb_mcp/duckdb_mcp.duckdb_extension"
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+pass() {
+    echo -e "${GREEN}✓ PASS${NC}: $1"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+fail() {
+    echo -e "${RED}✗ FAIL${NC}: $1"
+    if [ -n "${2:-}" ]; then
+        echo "  Expected: $2"
+    fi
+    if [ -n "${3:-}" ]; then
+        echo "  Got: $3"
+    fi
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+skip() {
+    echo -e "${YELLOW}○ SKIP${NC}: $1 — ${2:-}"
+    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+}
+
+echo "=========================================="
+echo "stdio stdout hygiene (Issue #74)"
+echo "=========================================="
+echo ""
+
+if [ ! -f "$DUCKDB" ]; then
+    echo -e "${RED}Error: DuckDB binary not found${NC}"
+    echo "  Tried: ${PROJECT_DIR}/build/release/duckdb"
+    echo "  Tried: ${PROJECT_DIR}/build/debug/duckdb"
+    exit 1
+fi
+if [ ! -f "$EXTENSION" ]; then
+    echo -e "${RED}Error: extension not found at ${EXTENSION}${NC}"
+    exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo -e "${RED}Error: python3 is required to validate the JSON-RPC stream${NC}"
+    exit 1
+fi
+
+# The DuckDB CLI renders a "Success" header block for every statement in the init
+# script, on stdout, before the server ever starts. That is the host's output, not the
+# transport's, and a stdio launcher has to silence it — which is what these two dot
+# commands do. Silencing it here is what lets the assertions below be absolute: once the
+# setup phase is quiet, EVERY byte on stdout must be protocol traffic.
+QUIET_SHELL='.mode list
+.headers off'
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Two requests: initialize, then a tools/call that runs the provoking SQL.
+REQUESTS_FILE="${TMPDIR_TEST}/requests.ldjson"
+cat > "$REQUESTS_FILE" <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"hygiene","version":"1"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"provoke","arguments":{}}}
+EOF
+
+#! Validates that every non-empty line on stdout is a JSON-RPC object, and that the
+#! responses to both request ids arrived. Prints "OK" or a diagnostic.
+VALIDATOR="${TMPDIR_TEST}/validate.py"
+cat > "$VALIDATOR" <<'PYEOF'
+import json, sys
+
+path = sys.argv[1]
+expected_ids = [int(a) for a in sys.argv[2:]] or [1, 2]
+with open(path, "rb") as f:
+    raw = f.read()
+
+problems = []
+seen_ids = set()
+for lineno, line in enumerate(raw.split(b"\n"), start=1):
+    if not line.strip():
+        continue
+    try:
+        text = line.decode("utf-8")
+    except UnicodeDecodeError:
+        problems.append("line %d is not valid UTF-8: %r" % (lineno, line[:60]))
+        continue
+    try:
+        msg = json.loads(text)
+    except ValueError:
+        problems.append("line %d is not JSON: %r" % (lineno, text[:80]))
+        continue
+    if not isinstance(msg, dict) or msg.get("jsonrpc") != "2.0":
+        problems.append("line %d is not a JSON-RPC 2.0 message: %r" % (lineno, text[:80]))
+        continue
+    if "id" in msg:
+        seen_ids.add(msg["id"])
+
+for want in expected_ids:
+    if want not in seen_ids:
+        problems.append("no response with id=%r on stdout" % (want,))
+
+if problems:
+    print("STRAY: " + " | ".join(problems))
+    sys.exit(1)
+print("OK")
+PYEOF
+
+#! run_case <name> <init-sql-file>
+#! Runs the stdio server with the given init script, feeding the request file on
+#! stdin. Captures stdout and stderr into separate files.
+run_case() {
+    local init_sql="$1"
+    local out="$2"
+    local err="$3"
+    local requests="${4:-$REQUESTS_FILE}"
+    timeout 30 "$DUCKDB" -unsigned -init "$init_sql" \
+        < "$requests" > "$out" 2> "$err"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: a DuckDB warning raised by the tool's own SQL (the reported repro).
+#
+# The deprecated `->` lambda makes the binder emit DUCKDB_LOG_WARNING while the
+# tools/call is executing. The CLI shell's log storage prints it to STDOUT.
+# ---------------------------------------------------------------------------
+INIT1="${TMPDIR_TEST}/init_warning.sql"
+cat > "$INIT1" <<EOF
+$QUIET_SHELL
+LOAD '${EXTENSION}';
+PRAGMA mcp_publish_tool(
+  'provoke',
+  'Runs SQL that makes DuckDB log a warning.',
+  'SELECT unnest(list_transform([''a'',''b''], x -> x || ''!'')) AS v',
+  '{}', '[]', 'markdown');
+PRAGMA mcp_server_start('stdio');
+EOF
+
+OUT1="${TMPDIR_TEST}/case1.out"
+ERR1="${TMPDIR_TEST}/case1.err"
+run_case "$INIT1" "$OUT1" "$ERR1"
+
+# Liveness: the provocation must actually have produced a warning somewhere,
+# otherwise the hygiene assertion below proves nothing.
+if grep -q "Deprecated lambda arrow" "$OUT1" "$ERR1" 2>/dev/null; then
+    pass "Case 1 liveness: the deprecated-lambda warning was emitted"
+
+    RESULT=$(python3 "$VALIDATOR" "$OUT1" 2>&1)
+    if [ "$RESULT" = "OK" ]; then
+        pass "Case 1: DuckDB warning during tools/call does not reach stdout"
+    else
+        fail "Case 1: DuckDB warning during tools/call leaked onto stdout" \
+             "only JSON-RPC on stdout" "$RESULT"
+    fi
+
+    # Nothing may be silently dropped either: the warning must still be visible.
+    if grep -q "Deprecated lambda arrow" "$ERR1"; then
+        pass "Case 1: the warning is preserved on stderr"
+    else
+        fail "Case 1: the warning was lost" "warning text on stderr" \
+             "$(head -c 200 "$ERR1")"
+    fi
+else
+    skip "Case 1" "this DuckDB build does not warn about the deprecated '->' lambda"
+    skip "Case 1 hygiene" "trigger unavailable"
+    skip "Case 1 preservation" "trigger unavailable"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: DuckDB's own stdout log storage, switched on from inside the session.
+#
+# Independent of the CLI shell: `SET logging_storage='stdout'` installs DuckDB's
+# StdOutLogStorage, which writes log rows via Printer::RawPrint(STREAM_STDOUT).
+# This trigger does not depend on any particular deprecation surviving.
+#
+# Logging is enabled through the `execute` tool rather than in the init script, so
+# that every log row is produced strictly WHILE the transport owns stdout. Anything
+# the init script logs happens before the server starts and is the launcher's
+# problem, not the transport's (see the stdio note in docs/guides/server-usage.md).
+# ---------------------------------------------------------------------------
+INIT2="${TMPDIR_TEST}/init_logstorage.sql"
+cat > "$INIT2" <<EOF
+$QUIET_SHELL
+LOAD '${EXTENSION}';
+PRAGMA mcp_server_start('stdio', '{"enable_execute_tool": true, "execute_allow_set": true}');
+EOF
+
+REQUESTS2="${TMPDIR_TEST}/requests_logstorage.ldjson"
+cat > "$REQUESTS2" <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"hygiene","version":"1"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"execute","arguments":{"statement":"SET GLOBAL logging_level = 'info'"}}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"execute","arguments":{"statement":"SET GLOBAL logging_storage = 'stdout'"}}}
+{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT 42 AS logged_value"}}}
+EOF
+
+OUT2="${TMPDIR_TEST}/case2.out"
+ERR2="${TMPDIR_TEST}/case2.err"
+run_case "$INIT2" "$OUT2" "$ERR2" "$REQUESTS2"
+
+# Liveness: DuckDB must actually have logged the query we ran, otherwise nothing
+# was provoked and the assertion below is vacuous.
+if grep -q "QueryLog" "$OUT2" "$ERR2" 2>/dev/null; then
+    pass "Case 2 liveness: DuckDB's stdout log storage produced entries in-session"
+else
+    fail "Case 2 liveness: DuckDB logged nothing" "QueryLog entries" "(none)"
+fi
+
+RESULT=$(python3 "$VALIDATOR" "$OUT2" 1 2 3 4 2>&1)
+if [ "$RESULT" = "OK" ]; then
+    pass "Case 2: DuckDB 'stdout' log storage does not reach the protocol stream"
+else
+    fail "Case 2: DuckDB 'stdout' log storage leaked onto stdout" \
+         "only JSON-RPC on stdout" "$RESULT"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: duckdb_mcp's own console logger.
+# ---------------------------------------------------------------------------
+INIT3="${TMPDIR_TEST}/init_mcplog.sql"
+cat > "$INIT3" <<EOF
+$QUIET_SHELL
+LOAD '${EXTENSION}';
+SET mcp_log_level = 'debug';
+SET mcp_console_logging = true;
+PRAGMA mcp_publish_tool(
+  'provoke',
+  'Runs a query while MCP console logging is on.',
+  'SELECT 42 AS v',
+  '{}', '[]', 'markdown');
+PRAGMA mcp_server_start('stdio');
+EOF
+
+OUT3="${TMPDIR_TEST}/case3.out"
+ERR3="${TMPDIR_TEST}/case3.err"
+run_case "$INIT3" "$OUT3" "$ERR3"
+
+# Liveness: the transport logs at DEBUG on every send/receive, so console logging
+# must have produced lines somewhere. If it did not, the assertion is vacuous.
+if grep -q "\[stdio\]" "$OUT3" "$ERR3" 2>/dev/null; then
+    pass "Case 3 liveness: MCP console logging produced output"
+
+    RESULT=$(python3 "$VALIDATOR" "$OUT3" 2>&1)
+    if [ "$RESULT" = "OK" ]; then
+        pass "Case 3: MCP console logging does not reach the protocol stream"
+    else
+        fail "Case 3: MCP console logging leaked onto stdout" \
+             "only JSON-RPC on stdout" "$RESULT"
+    fi
+else
+    fail "Case 3 liveness: MCP console logging produced nothing" \
+         "[stdio] diagnostics on stdout or stderr" "(none)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: stdout must be restored once the session ends, so a host that keeps
+# using the connection afterwards is not left writing into the void.
+# ---------------------------------------------------------------------------
+INIT4="${TMPDIR_TEST}/init_restore.sql"
+cat > "$INIT4" <<EOF
+$QUIET_SHELL
+LOAD '${EXTENSION}';
+PRAGMA mcp_publish_tool('provoke', 'noop', 'SELECT 42 AS v', '{}', '[]', 'markdown');
+PRAGMA mcp_server_start('stdio');
+SELECT 'stdout-restored-marker' AS marker;
+EOF
+
+OUT4="${TMPDIR_TEST}/case4.out"
+ERR4="${TMPDIR_TEST}/case4.err"
+run_case "$INIT4" "$OUT4" "$ERR4"
+
+if grep -q "stdout-restored-marker" "$OUT4"; then
+    pass "Case 4: stdout is restored to the host after the session ends"
+else
+    fail "Case 4: stdout was not restored after the session" \
+         "marker on stdout" "$(head -c 200 "$OUT4")"
+fi
+
+echo ""
+echo "=========================================="
+echo -e "Passed:  ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Failed:  ${RED}${TESTS_FAILED}${NC}"
+echo -e "Skipped: ${YELLOW}${TESTS_SKIPPED}${NC}"
+echo "=========================================="
+
+if [ "$TESTS_FAILED" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
# fix(stdio): give the transport exclusive ownership of stdout

Closes #74

## The mechanism

JSON-RPC over stdio requires fd 1 to carry framed protocol messages and nothing
else. It does not, because several writers reach fd 1 without going through the
transport. The one in the report is the DuckDB CLI itself:

- `tools/shell/shell.cpp:1164` `RegisterShellLogger()` registers `ShellLogStorage`
  as the **global** log storage on the `DatabaseInstance`, calls
  `SetEnableLogging()`, and sets the level to `LOG_WARNING`.
- `ShellLogStorage::WriteLogEntry` (`tools/shell/shell_renderer.cpp:1855`) prints
  each entry via `shell_highlight.PrintText(..., PrintOutput::STDOUT, ...)`,
  wrapped in ANSI colour codes with a trailing `\033[00m` reset
  (`ShellHighlight::ResetTerminalCode`, `shell_highlight.cpp:676`).

So every `DUCKDB_LOG_WARNING` raised anywhere in DuckDB or in any loaded extension
is printed to stdout — including one raised *inside a query the MCP client itself
triggered* via `tools/call`, which is executed on the same thread that owns the
protocol stream. The deprecated `->` lambda warning
(`src/planner/binder/expression/bind_function_expression.cpp:33`) is the easiest
trigger; `duckdb_zim`'s "skipped un-openable archive" warning under
`ignore_errors := true` is the one that bit the reporter in the field.

Reproduced verbatim against a pre-fix build:

```
{"jsonrpc":"2.0","result":{...},"id":1}
^[[90mWARNING:
^[[00m^[[90mDeprecated lambda arrow (->) detected. ...
...
^[[00m{"jsonrpc":"2.0","result":{"content":[...]},"id":2}
```

The response to `id=2` no longer begins with `{`. A strict client drops it — and
what is lost is a **successful** response, silently.

Three further writers reach the same descriptor:

- `SET logging_storage='stdout'` installs DuckDB's own `StdOutLogStorage`, which
  writes rows via `Printer::RawPrint(OutputStream::STREAM_STDOUT)`
  (`src/logging/log_storage.cpp:256`).
- `TerminalProgressBarDisplay` writes to `STREAM_STDOUT`.
- This extension's **own** console logger wrote every non-ERROR line to
  `std::cout` (`src/duckdb_mcp_logging.cpp:85`), despite the
  `mcp_console_logging` option being documented as "console/stderr".

## The fix

Filtering the writers cannot work — the set is open-ended and grows with every
extension the user loads, and the issue's own suggestion (`SET enable_logging =
false` for the session) suppresses diagnostics rather than relocating them, and
does not cover `Printer::RawPrint` or a third-party `printf`.

So the transport takes the descriptor away from them instead. On `Connect()` the
new `ProtocolStdout` guard:

1. flushes `std::cout` / `stdout` so nothing already buffered for the real stdout
   is mis-routed,
2. `dup(1)` into a private descriptor that only the transport writes to,
3. `dup2(2, 1)` — from that moment every stray write, whoever makes it and through
   whatever API, goes to **stderr**.

`Send()` writes the framed message to the private descriptor with `write(2)`
rather than through `std::cout` (which now points at stderr). `Disconnect()`
restores fd 1 and closes the private descriptor; the destructor calls it, so an
exception out of the connection loop cannot leak the redirect.

Nothing is suppressed — stray output still reaches stderr, the channel a
supervisor or container collects — it just cannot desynchronise the channel.
`Acquire()` failing is non-fatal: the transport logs a warning and falls back to
the old behaviour.

Also routes `MCPLogger` console output to stderr at every level. A diagnostic
logger must not aim at the protocol channel in the first place.

Windows uses `_dup`/`_dup2`/`_close`/`_write` via `<io.h>`; the file is already
excluded from the Emscripten build.

## Regression test — failing before, passing after

`test/stdio/test_stdio_stdout_hygiene.sh` provokes each mechanism in turn and
asserts stdout parses as nothing but JSON-RPC 2.0 messages, with the expected
response ids present. Every provocation is paired with a **liveness** assertion
that the stray writer actually fired, so the suite cannot pass vacuously the day
DuckDB stops emitting the trigger it uses.

Cases:

1. a DuckDB warning raised by the tool's own SQL during `tools/call` (the report's
   repro) — plus an assertion that the warning is **preserved** on stderr;
2. `SET GLOBAL logging_storage='stdout'` switched on *from inside the session*
   through the `execute` tool, so every log row is produced while the transport
   owns stdout;
3. `SET mcp_log_level='debug'` + `SET mcp_console_logging=true`;
4. stdout is restored to the host after the session ends.

Same build tree, `src/` stashed then restored:

```
$ git stash push -- src/ && make release -j16 && ./test/stdio/test_stdio_stdout_hygiene.sh
✓ PASS: Case 1 liveness: the deprecated-lambda warning was emitted
✗ FAIL: Case 1: DuckDB warning during tools/call leaked onto stdout
  Got: STRAY: line 2 is not JSON: '\x1b[90mWARNING:' | ... | no response with id=2 on stdout
✗ FAIL: Case 1: the warning was lost
✓ PASS: Case 2 liveness: DuckDB's stdout log storage produced entries in-session
✗ FAIL: Case 2: DuckDB 'stdout' log storage leaked onto stdout
✓ PASS: Case 3 liveness: MCP console logging produced output
✗ FAIL: Case 3: MCP console logging leaked onto stdout
✓ PASS: Case 4: stdout is restored to the host after the session ends
Passed: 4   Failed: 4
```

```
$ git stash pop && make release -j16 && ./test/stdio/test_stdio_stdout_hygiene.sh
Passed: 8   Failed: 0   Skipped: 0
```

Wired into `MainDistributionPipeline.yml` alongside the existing integration and
HTTP transport steps.

## Out of scope, documented instead

Statements that run **before** `mcp_server_start` are rendered by the CLI — one
`Success` block per statement, on stdout — and that is outside the transport's
reach because the server does not exist yet. A stdio launcher has to silence it
(`.mode list` / `.headers off`, and `PRAGMA` rather than `SELECT` for publishing
calls). Documented in the new stdio note in `docs/guides/server-usage.md`; the
regression test uses the same prelude, which is what lets its assertions be
absolute rather than "from the first `{` onward".

## Verification

- `make test_release` — 1201 assertions, 36 cases, all pass
- `test/integration/run_integration_tests.sh` — 56/56
- `test/http/test_http_transport.sh` — 27/27
- `test/stdio/test_stdio_transport_bugs.sh` — 6/6
- `test/stdio/test_stdio_stdout_hygiene.sh` — 8/8 (0/8 before the fix)

`make format-fix` was run and then reverted on three files it touched but this PR
does not: it mangles the JS inside `EM_JS` macros in
`src/server/webmcp_transport.cpp` (`!==` becomes `!= =`), which would break the
WASM build. Flagging separately — `format-check` cannot be run wholesale on this
tree as it stands.
