### PR TITLE
Pin table-function parameter binding with tests; #71 was fixed in v2.1.2

### DIFF
--- a/test/sql/mcp_prepared_params.test
+++ b/test/sql/mcp_prepared_params.test
@@ -433,8 +433,16 @@ SELECT mcp_publish_tool(
 ----
 true
 
+# __TEST_DIR__ expands to a NATIVE path, so on Windows it contains backslashes.
+# A backslash inside a JSON string literal starts an escape sequence, so splicing
+# the raw path into the request body yields invalid JSON ("...tempdir\7128/..." —
+# \7 is not an escape) and the peer rejects the whole request. Every other test in
+# this suite that embeds __TEST_DIR__ in JSON avoids the problem with
+# `require notwindows`; that would cost this file its sixty other assertions on
+# Windows, so normalise the separator instead. read_csv accepts forward slashes on
+# every platform.
 query I
-SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":110,"method":"tools/call","params":{"name":"tf71_overloaded_path","arguments":{"path":"__TEST_DIR__/tf71.csv"}}}') LIKE '%kappa%';
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":110,"method":"tools/call","params":{"name":"tf71_overloaded_path","arguments":{"path":"' || replace('__TEST_DIR__/tf71.csv', '\', '/') || '"}}}') LIKE '%kappa%';
 ----
 true
 

--- a/test/sql/mcp_prepared_params.test
+++ b/test/sql/mcp_prepared_params.test
@@ -368,6 +368,118 @@ SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":60,"method":"tools/call","
 true
 
 # =============================================================================
+# PREP-12: Table function arguments — the shape reported in issue #71
+#
+# The report claimed $param "is not replaced" in a table function argument, on the
+# theory that "table functions are resolved at parse time, not execution time".
+# That is not how DuckDB binds them: a statement whose table function arguments
+# contain unresolved parameters is re-bound at execution time with the supplied
+# values. PREP-07 and PREP-08 pin the simple positional and named-argument cases;
+# this section pins the harder shapes the report actually used, so the claim
+# cannot quietly become true again:
+#
+#   - the parameter in a NON-FIRST positional slot, flanked by CAST'd constants
+#   - the parameter as the first argument of an OVERLOADED table function, where
+#     the overload cannot be chosen until the value is known
+#   - a scalar EXPRESSION (not a literal) in the first argument slot, with both a
+#     hardcoded and a parameterized named argument alongside
+# =============================================================================
+
+statement ok
+COPY (SELECT * FROM (VALUES (1, 'iota'), (2, 'kappa')) t(id, label)) TO '__TEST_DIR__/tf71.csv' (HEADER);
+
+# --- parameter in a middle positional slot -----------------------------------
+
+query I
+SELECT mcp_publish_tool(
+    'tf71_middle_slot',
+    'Parameter in a non-first positional argument, between CAST constants',
+    'SELECT * FROM range(CAST(0 AS BIGINT), $n, CAST(1 AS BIGINT))',
+    '{"n": {"type": "integer", "description": "Exclusive upper bound"}}',
+    '["n"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"tf71_middle_slot","arguments":{"n":3}}}') LIKE '%\"range\":2%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"tf71_middle_slot","arguments":{"n":3}}}') NOT LIKE '%\"range\":3%';
+----
+true
+
+# A different value must re-bind rather than reuse the first call's plan
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":102,"method":"tools/call","params":{"name":"tf71_middle_slot","arguments":{"n":6}}}') LIKE '%\"range\":5%';
+----
+true
+
+# --- parameter as the first argument of an overloaded table function ---------
+# read_csv is a function SET: read_csv(VARCHAR, ...) and read_csv(VARCHAR[], ...).
+# The overload cannot be picked from an unresolved parameter, so this is the case
+# the report's "resolved at parse time" theory would have broken.
+
+query I
+SELECT mcp_publish_tool(
+    'tf71_overloaded_path',
+    'Parameter as the first argument of an overloaded table function',
+    'SELECT * FROM read_csv($path, header := true)',
+    '{"path": {"type": "string", "description": "CSV path"}}',
+    '["path"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":110,"method":"tools/call","params":{"name":"tf71_overloaded_path","arguments":{"path":"__TEST_DIR__/tf71.csv"}}}') LIKE '%kappa%';
+----
+true
+
+# --- scalar expression in the argument slot, hardcoded + parameterized named args
+# The reported template composed its first argument with getenv() and hardcoded
+# several named arguments while parameterizing others. getenv() needs an
+# environment this test cannot set, so concat() stands in for it: what matters is
+# that the slot holds an expression to fold rather than a literal.
+
+query I
+SELECT mcp_publish_tool(
+    'tf71_expr_and_named',
+    'Expression in the path slot, one hardcoded and one bound named argument',
+    'SELECT * FROM read_csv(concat(''__TEST_DIR__'', ''/tf71.csv''), header := true, all_varchar := $av)',
+    '{"av": {"type": "boolean", "description": "Read every column as VARCHAR"}}',
+    '["av"]'
+) LIKE 'SUCCESS%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":120,"method":"tools/call","params":{"name":"tf71_expr_and_named","arguments":{"av":true}}}') LIKE '%iota%';
+----
+true
+
+# all_varchar := true → the id column comes back quoted
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":121,"method":"tools/call","params":{"name":"tf71_expr_and_named","arguments":{"av":true}}}') LIKE '%\"id\":\"1\"%';
+----
+true
+
+# all_varchar := false → the same column comes back as a number. The two calls
+# differ only in the bound value, so this pins that the value reached the table
+# function's named argument rather than being ignored or left as a literal.
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":122,"method":"tools/call","params":{"name":"tf71_expr_and_named","arguments":{"av":false}}}') LIKE '%\"id\":1%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"tf71_expr_and_named","arguments":{"av":false}}}') NOT LIKE '%\"id\":\"1\"%';
+----
+true
+
+# =============================================================================
 # CLEANUP
 # =============================================================================
 


### PR DESCRIPTION
# test(tools): pin $param binding in the issue-#71 table function shapes

Refs #71 — **and recommends closing it as already fixed.** No production code
changes here; see "What I found" before merging.

## What I found

#71 says `mcp_publish_tool` "doesn't bind `$param` for table functions", on the
theory that "table functions are resolved at parse time, not execution time".
That theory is wrong for DuckDB 1.5, and the behaviour **does not reproduce on
main**. DuckDB catches `ParameterNotResolvedException` during bind, marks the
prepared statement `bound_all_parameters = false`, and re-binds it at execution
time with the supplied values.

Evidence, all against a build of `origin/main`:

- Six published-tool shapes exercised end-to-end through `tools/call` — bare
  positional (`range($n)`), non-first positional (`range(0, $n, 1)`), overloaded
  first argument (`read_csv($path, header := true)`), `getenv()`-composed path
  plus a bound `WHERE` param, `glob($pat)`, and a bound *named* argument
  (`read_csv(getenv('T71_CSV'), header := $h)`) — all returned correct,
  value-dependent results.
- The reported function itself: I installed the community `zim` extension and ran
  `PREPARE p AS SELECT * FROM zim_search('/nonexistent.zim', $q, ignore_errors :=
  true, with_snippet := true, result_offset := CAST(0 AS BIGINT), max_results :=
  CAST(10 AS BIGINT)); EXECUTE p(q := 'x');`. It reaches `zim_search`'s own
  file-open error, byte-identical to the same statement with a literal in place of
  `$q`. No parameter error at any point. The same holds with `$path` in the
  overload-ambiguous first slot and with a parameterised named argument.

**The real root cause was already fixed**, by 3531ee6 ("fix(tools): bind only
params the SQL template references"), first released in **v2.1.2**. Before it,
`SQLToolHandler` bound every declared schema property, so DuckDB rejected the call
with `Invalid Input Error: Parameter argument/count mismatch`. The reporter's
environment line says **duckdb_mcp 2.0.0**, and `v2.0.0-rc2:src/server/tool_handlers.cpp`
confirms the unfiltered `prepared->Execute(named_params)`. 3531ee6 also added the
"Table Function Arguments" section to `docs/guides/custom-tools.md` — so the
"documentation" half of the issue's label is already satisfied on main too.

The issue was filed at 2026-08-05T17:37Z; 3531ee6 landed at 2026-08-05 19:53Z.
It looks like it was simply never closed.

Separately worth the coordinator's attention: the reporter's field symptom is
better explained by **#74**. Their template used `ignore_errors := true` against
an unreadable archive, which makes `duckdb_zim` emit a warning that the CLI's log
storage prints **to stdout** mid-stream — I reproduced exactly that with zim
installed. The response is then dropped by the client and the tool looks like it
failed to bind. The same reporter filed #74 twelve days later describing that
mechanism directly.

## What this PR adds

PREP-07 and PREP-08 (from 3531ee6) cover a bare positional argument and a bare
named argument. This adds the harder shapes the report's own template actually
used, which were not covered, so the claim cannot quietly become true again:

- `$param` in a **non-first positional slot**, flanked by `CAST`'d constants —
  `range(CAST(0 AS BIGINT), $n, CAST(1 AS BIGINT))`, mirroring the report's
  `result_offset := CAST(0 AS BIGINT)`
- `$param` as the first argument of an **overloaded** table function, where the
  overload cannot be chosen until the value is known (`read_csv` is a function set
  over `VARCHAR` and `VARCHAR[]`, exactly like `zim_search`)
- a scalar **expression** rather than a literal in the first argument slot, with
  one hardcoded and one bound named argument alongside — the shape of
  `getenv('ZIM_FILES')` plus `ignore_errors := true`. `getenv()` needs an
  environment the sqllogictest runner cannot set, so `concat()` stands in; what
  matters is that the slot holds an expression to fold rather than a literal.

Each parameterised case is asserted with two different argument values, matching
on the exact JSON key/value (`\"range\":5`, `\"id\":\"1\"` vs `\"id\":1`), so a
value that never reached the function shows up as an unchanged result rather than
passing by luck.

## Verification

- `make test_release` — 1213 assertions, 36 cases, all pass (was 1201 before)
- `test/sql/mcp_prepared_params.test` alone — 60 assertions

## Recommendation

Merge this for the coverage, then close #71 as fixed in v2.1.2 with a note that
the reporter should upgrade from 2.0.0, and that #74 is the likely cause of the
symptom they saw.
