### PR TITLE
README: correct the license badge to Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DuckDB MCP Extension
 
 [![Documentation](https://img.shields.io/badge/docs-readthedocs-blue)](https://duckdb-mcp.readthedocs.io/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) extension for DuckDB that enables seamless integration between SQL databases and AI assistants like Claude.
 


### PR DESCRIPTION
# docs: correct the README licence badge to Apache-2.0

`LICENSE` (Apache License 2.0), `NOTICE` ("Licensed under the Apache License,
Version 2.0"), the README's own License section, `docs/index.md` and the
community-extensions registry all say Apache-2.0. The badge on README line 4 was
the last thing still claiming MIT, and a badge is the first licence signal a
reader gets.

One line. `grep -rn MIT` over the tree (excluding submodules and `build/`) now
returns nothing.

Note for the record: the README's License section and `docs/index.md` were
*already* corrected on `main` — only the badge was left. A local checkout on an
older branch still shows the stale MIT text in those two places, which is what
made it look like three separate defects.
