### PR TITLE
Triage #67: both boxes already handled; five silent-corruption bugs found next door

### DIFF
--- a/src/duckdb_mcp_extension.cpp
+++ b/src/duckdb_mcp_extension.cpp
@@ -1567,8 +1567,17 @@ static void SetMCPDisableServing(ClientContext &context, SetScope scope, Value &
 
 // MCP-Compliant Pagination Functions
 
-// List resources with optional cursor (MCP-compliant)
-static void MCPListResourcesWithCursorFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+//! Shared body for the cursor-aware `mcp_list_*` overloads.
+//!
+//! MCP paginates `resources/list`, `tools/list` and `prompts/list` with an
+//! opaque `cursor` parameter on the list method itself. These overloads used to
+//! send `tools/call` for an invented tool name (`list_resources_paginated` and
+//! friends) instead. No MCP server exposes those tools, so every call came back
+//! a JSON-RPC error, which the catch below turned into a `{"error": ...}` value
+//! -- a NULL to the `json_extract_string` in the documented paging recipe, with
+//! no exception anywhere. See test/sql/mcp_list_cursor.test.
+static void MCPListWithCursorFunction(DataChunk &args, ExpressionState &state, Vector &result, const char *list_method,
+                                      const char *what) {
 	auto &server_vector = args.data[0];
 	auto &cursor_vector = args.data[1];
 
@@ -1591,121 +1600,54 @@ static void MCPListResourcesWithCursorFunction(DataChunk &args, ExpressionState 
 				throw InvalidInputException("MCP server not attached: " + server_name);
 			}
 
-			// Use tool call for pagination instead of modifying standard MCP methods
-			Value call_params = Value::STRUCT(
-			    {{"name", Value("list_resources_paginated")},
-			     {"arguments",
-			      Value(cursor.empty() ? "{}"
-			                           : "{\"cursor\": \"" + ResultFormatter::EscapeJsonString(cursor) + "\"}")}});
-
-			// Send MCP tool call for pagination
-			auto response = connection->SendRequest(MCPMethods::TOOLS_CALL, call_params);
-
-			if (response.IsError()) {
-				throw IOException("MCP list resources failed: " + response.error.message);
+			if (!connection->IsInitialized()) {
+				if (!connection->Initialize()) {
+					throw IOException("Failed to initialize MCP connection: " + connection->GetLastError());
+				}
 			}
 
-			// Return raw JSON response (same as existing functions)
+			// An empty cursor means "give me the first page". Send no cursor at
+			// all in that case -- an empty cursor is not a valid opaque token and
+			// servers are entitled to reject it.
+			Value params;
+			if (cursor.empty()) {
+				params = Value::STRUCT({});
+			} else {
+				params = Value("{\"cursor\": \"" + ResultFormatter::EscapeJsonString(cursor) + "\"}");
+			}
+
+			auto response = connection->SendRequest(list_method, params);
+
+			if (response.IsError()) {
+				throw IOException("MCP list " + string(what) + " failed: " + response.error.message);
+			}
+
+			// Return the raw JSON result, `nextCursor` included, so the caller can
+			// feed it straight back in for the next page.
 			result_data[i] = StringVector::AddString(result, response.result.ToString());
 
 		} catch (const std::exception &e) {
-			result_data[i] = StringVector::AddString(result, "{\"error\": \"" + string(e.what()) + "\"}");
+			// Escaped: an error message containing a quote or a backslash would
+			// otherwise emit a malformed value into a JSON-typed column.
+			result_data[i] =
+			    StringVector::AddString(result, "{\"error\": \"" + ResultFormatter::EscapeJsonString(e.what()) + "\"}");
 		}
 	}
+}
+
+// List resources with optional cursor (MCP-compliant)
+static void MCPListResourcesWithCursorFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	MCPListWithCursorFunction(args, state, result, MCPMethods::RESOURCES_LIST, "resources");
 }
 
 // List tools with optional cursor (MCP-compliant)
 static void MCPListToolsWithCursorFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	auto &server_vector = args.data[0];
-	auto &cursor_vector = args.data[1];
-
-	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = CompatGetDataMutable<string_t>(result);
-	auto &registry = MCPInstanceState::Get(state.GetContext()).connection_registry;
-
-	for (idx_t i = 0; i < args.size(); i++) {
-		if (server_vector.GetValue(i).IsNull()) {
-			result_data[i] = StringVector::AddString(result, "null");
-			continue;
-		}
-
-		string server_name = server_vector.GetValue(i).ToString();
-		string cursor = cursor_vector.GetValue(i).IsNull() ? "" : cursor_vector.GetValue(i).ToString();
-
-		try {
-			auto connection = registry.GetConnection(server_name);
-			if (!connection) {
-				throw InvalidInputException("MCP server not attached: " + server_name);
-			}
-
-			// Use tool call for pagination
-			Value call_params = Value::STRUCT(
-			    {{"name", Value("list_tools_paginated")},
-			     {"arguments",
-			      Value(cursor.empty() ? "{}"
-			                           : "{\"cursor\": \"" + ResultFormatter::EscapeJsonString(cursor) + "\"}")}});
-
-			// Send MCP tool call for pagination
-			auto response = connection->SendRequest(MCPMethods::TOOLS_CALL, call_params);
-
-			if (response.IsError()) {
-				throw IOException("MCP list tools failed: " + response.error.message);
-			}
-
-			// Return raw JSON response (same as existing functions)
-			result_data[i] = StringVector::AddString(result, response.result.ToString());
-
-		} catch (const std::exception &e) {
-			result_data[i] = StringVector::AddString(result, "{\"error\": \"" + string(e.what()) + "\"}");
-		}
-	}
+	MCPListWithCursorFunction(args, state, result, MCPMethods::TOOLS_LIST, "tools");
 }
 
 // List prompts with optional cursor (MCP-compliant)
 static void MCPListPromptsWithCursorFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	auto &server_vector = args.data[0];
-	auto &cursor_vector = args.data[1];
-
-	result.SetVectorType(VectorType::FLAT_VECTOR);
-	auto result_data = CompatGetDataMutable<string_t>(result);
-	auto &registry = MCPInstanceState::Get(state.GetContext()).connection_registry;
-
-	for (idx_t i = 0; i < args.size(); i++) {
-		if (server_vector.GetValue(i).IsNull()) {
-			result_data[i] = StringVector::AddString(result, "null");
-			continue;
-		}
-
-		string server_name = server_vector.GetValue(i).ToString();
-		string cursor = cursor_vector.GetValue(i).IsNull() ? "" : cursor_vector.GetValue(i).ToString();
-
-		try {
-			auto connection = registry.GetConnection(server_name);
-			if (!connection) {
-				throw InvalidInputException("MCP server not attached: " + server_name);
-			}
-
-			// Use tool call for pagination
-			Value call_params = Value::STRUCT(
-			    {{"name", Value("list_prompts_paginated")},
-			     {"arguments",
-			      Value(cursor.empty() ? "{}"
-			                           : "{\"cursor\": \"" + ResultFormatter::EscapeJsonString(cursor) + "\"}")}});
-
-			// Send MCP tool call for pagination
-			auto response = connection->SendRequest(MCPMethods::TOOLS_CALL, call_params);
-
-			if (response.IsError()) {
-				throw IOException("MCP list prompts failed: " + response.error.message);
-			}
-
-			// Return raw JSON response (same as existing functions)
-			result_data[i] = StringVector::AddString(result, response.result.ToString());
-
-		} catch (const std::exception &e) {
-			result_data[i] = StringVector::AddString(result, "{\"error\": \"" + string(e.what()) + "\"}");
-		}
-	}
+	MCPListWithCursorFunction(args, state, result, MCPMethods::PROMPTS_LIST, "prompts");
 }
 
 #endif // !__EMSCRIPTEN__
@@ -1824,8 +1766,12 @@ static void MCPRenderPromptTemplateFunction(DataChunk &args, ExpressionState &st
 					yyjson_val *key, *val;
 					while ((key = yyjson_obj_iter_next(&iter))) {
 						val = yyjson_obj_iter_get_val(key);
-						if (yyjson_is_str(val)) {
-							template_args[yyjson_get_str(key)] = yyjson_get_str(val);
+						// Numbers and booleans are legitimate argument values;
+						// skipping them left the variable unbound and Render()
+						// substituted an optional one with the empty string.
+						string arg_str;
+						if (JSONUtils::ScalarAsString(val, arg_str)) {
+							template_args[yyjson_get_str(key)] = arg_str;
 						}
 					}
 				}

--- a/src/include/json_utils.hpp
+++ b/src/include/json_utils.hpp
@@ -81,6 +81,16 @@ public:
 	//! Get any value as string representation (works for int, bool, string, etc.)
 	static string GetValueAsString(yyjson_val *obj, const char *key, const string &default_value = "");
 
+	//! Render a JSON *scalar* (string, number, boolean) as the plain text a
+	//! caller should bind or substitute; returns false for null, objects and
+	//! arrays, which have no meaningful scalar form.
+	//!
+	//! Numbers are written by yyjson, which emits the shortest representation
+	//! that reads back to the same double. Do not use std::to_string here: it
+	//! formats with "%f" and silently truncates, so 1e-7 becomes "0.000000",
+	//! which std::stod then parses cleanly as 0.0.
+	static bool ScalarAsString(yyjson_val *val, string &out);
+
 	//! Get int value from JSON object
 	static int64_t GetInt(yyjson_val *obj, const char *key, int64_t default_value = 0);
 

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -286,6 +286,48 @@ string JSONUtils::GetString(yyjson_val *obj, const char *key, const string &defa
 	return str ? string(str) : default_value;
 }
 
+bool JSONUtils::ScalarAsString(yyjson_val *val, string &out) {
+	if (!val) {
+		return false;
+	}
+
+	if (yyjson_is_str(val)) {
+		const char *str = yyjson_get_str(val);
+		if (!str) {
+			return false;
+		}
+		out = string(str, yyjson_get_len(val));
+		return true;
+	}
+
+	if (yyjson_is_bool(val)) {
+		out = yyjson_get_bool(val) ? "true" : "false";
+		return true;
+	}
+
+	if (yyjson_is_int(val)) {
+		out = std::to_string(yyjson_get_sint(val));
+		return true;
+	}
+
+	if (yyjson_is_real(val)) {
+		// NOT std::to_string: that formats with "%f" -- six digits after the
+		// decimal point -- so 1e-7 becomes "0.000000" and 1.23456789 becomes
+		// "1.234568". Both parse cleanly with std::stod, so the truncation is
+		// invisible to every caller downstream. yyjson writes the shortest text
+		// that reads back to the same double.
+		char *num_str = yyjson_val_write(val, 0, nullptr);
+		if (!num_str) {
+			return false;
+		}
+		out = string(num_str);
+		free(num_str);
+		return true;
+	}
+
+	return false; // null, object, array: no meaningful scalar form
+}
+
 string JSONUtils::GetValueAsString(yyjson_val *obj, const char *key, const string &default_value) {
 	if (!obj || !key) {
 		return default_value;
@@ -296,26 +338,21 @@ string JSONUtils::GetValueAsString(yyjson_val *obj, const char *key, const strin
 		return default_value;
 	}
 
-	// Handle different JSON types
-	if (yyjson_is_str(val)) {
-		const char *str = yyjson_get_str(val);
-		return str ? string(str) : default_value;
-	} else if (yyjson_is_int(val)) {
-		return std::to_string(yyjson_get_sint(val));
-	} else if (yyjson_is_real(val)) {
-		return std::to_string(yyjson_get_real(val));
-	} else if (yyjson_is_bool(val)) {
-		return yyjson_get_bool(val) ? "true" : "false";
-	} else if (yyjson_is_null(val)) {
+	string scalar;
+	if (ScalarAsString(val, scalar)) {
+		return scalar;
+	}
+
+	if (yyjson_is_null(val)) {
 		return "null";
-	} else {
-		// For objects/arrays, return JSON representation
-		char *json_str = yyjson_val_write(val, 0, nullptr);
-		if (json_str) {
-			string result(json_str);
-			free(json_str);
-			return result;
-		}
+	}
+
+	// For objects/arrays, return JSON representation
+	char *json_str = yyjson_val_write(val, 0, nullptr);
+	if (json_str) {
+		string result(json_str);
+		free(json_str);
+		return result;
 	}
 
 	return default_value;

--- a/src/protocol/mcp_message.cpp
+++ b/src/protocol/mcp_message.cpp
@@ -92,7 +92,14 @@ string MCPMessage::ToJSON() const {
 						}
 					}
 
-				} else if (method == "tools/call") {
+				} else if (method == "tools/call" || method == "prompts/get") {
+					// `tools/call` and `prompts/get` take the same params shape: a
+					// `name` plus an `arguments` object. `prompts/get` used to fall
+					// through to the catch-all at the bottom of this chain, which
+					// replaced the whole struct with `{}`. The prompt name and
+					// every argument were dropped on the wire, and the peer
+					// answered "Missing prompt name" -- which reads like a missing
+					// prompt rather than a client that corrupted its own request.
 					// Extract tool name and arguments from params struct
 					params_obj = JSONUtils::CreateObject(doc);
 					if (params.type().id() == LogicalTypeId::STRUCT) {
@@ -152,8 +159,14 @@ string MCPMessage::ToJSON() const {
 					if (!params_obj) {
 						params_obj = JSONUtils::CreateObject(doc);
 					}
+				} else if (params.type().id() == LogicalTypeId::STRUCT) {
+					// Any other method carrying a STRUCT: serialise it faithfully.
+					// The comment on the branch below claimed to cover only
+					// "non-STRUCT" types, but a STRUCT for an unlisted method
+					// landed there too and was silently replaced with `{}`.
+					params_obj = JSONUtils::ValueToJSON(doc, params);
 				} else {
-					// Default empty params object for non-VARCHAR, non-STRUCT types
+					// Default empty params object for the remaining types
 					params_obj = JSONUtils::CreateObject(doc);
 				}
 

--- a/src/protocol/mcp_template.cpp
+++ b/src/protocol/mcp_template.cpp
@@ -1,4 +1,5 @@
 #include "protocol/mcp_template.hpp"
+#include "json_utils.hpp"
 #include "duckdb_compat.hpp"
 #include "protocol/mcp_message.hpp"
 #include "duckdb_mcp_logging.hpp"
@@ -289,8 +290,14 @@ MCPMessage MCPTemplateManager::HandlePromptsGet(const MCPMessage &request) const
 				yyjson_val *key;
 				while ((key = yyjson_obj_iter_next(&iter))) {
 					yyjson_val *val = yyjson_obj_iter_get_val(key);
-					if (yyjson_is_str(val)) {
-						args[yyjson_get_str(key)] = yyjson_get_str(val);
+					// Accept numbers and booleans, not only strings. A client
+					// following an integer-typed argument schema sends a JSON
+					// number; dropping it here left the variable unbound, and
+					// Render() then substituted an optional variable with the
+					// empty string -- a mangled prompt returned as success.
+					string arg_str;
+					if (JSONUtils::ScalarAsString(val, arg_str)) {
+						args[yyjson_get_str(key)] = arg_str;
 					}
 				}
 			}
@@ -316,8 +323,11 @@ MCPMessage MCPTemplateManager::HandlePromptsGet(const MCPMessage &request) const
 						yyjson_val *akey;
 						while ((akey = yyjson_obj_iter_next(&iter))) {
 							yyjson_val *val = yyjson_obj_iter_get_val(akey);
-							if (yyjson_is_str(val)) {
-								args[yyjson_get_str(akey)] = yyjson_get_str(val);
+							// Same as the wire path above: numbers and booleans
+							// are legitimate argument values.
+							string arg_str;
+							if (JSONUtils::ScalarAsString(val, arg_str)) {
+								args[yyjson_get_str(akey)] = arg_str;
 							}
 						}
 					}

--- a/src/protocol/mcp_transport.cpp
+++ b/src/protocol/mcp_transport.cpp
@@ -17,6 +17,34 @@
 
 namespace duckdb {
 
+namespace {
+
+//! Compare two JSON-RPC ids by their textual form.
+//!
+//! A peer is free to echo a numeric id back as a number or as a string, and
+//! `MCPMessage::FromJSON` parses those into a BIGINT and a VARCHAR Value
+//! respectively; both mean the same request, so compare the rendered text.
+bool MessageIdMatches(const Value &expected, const Value &actual) {
+	if (expected.IsNull()) {
+		return true; // nothing to match against
+	}
+	if (actual.IsNull()) {
+		return false;
+	}
+	return expected.ToString() == actual.ToString();
+}
+
+string DescribeId(const Value &id) {
+	return id.IsNull() ? string("<null>") : id.ToString();
+}
+
+//! How many unrelated messages to step over before giving up on a response.
+//! Notifications are unbounded in principle, so this is a liveness backstop,
+//! not a protocol limit.
+constexpr int MAX_UNRELATED_MESSAGES = 64;
+
+} // namespace
+
 #ifdef _WIN32
 namespace {
 
@@ -55,6 +83,11 @@ bool StdioTransport::Connect() {
 
 	MCP_LOG_INFO("TRANSPORT", "Connecting to MCP server: %s", config.command_path);
 
+	// Never carry a previous process's trailing bytes into the new one: after a
+	// reconnect they would be handed to the new process's first read as if they
+	// were its answer.
+	read_buffer.clear();
+
 	if (!StartProcess()) {
 		MCP_LOG_ERROR("TRANSPORT", "Failed to start MCP server process: %s", config.command_path);
 		return false;
@@ -76,6 +109,7 @@ void StdioTransport::Disconnect() {
 
 	MCP_LOG_INFO("TRANSPORT", "Disconnecting from MCP server: %s", config.command_path);
 	StopProcess();
+	read_buffer.clear();
 	connected = false;
 	MCP_LOG_DEBUG("TRANSPORT", "Disconnected from MCP server: %s", config.command_path);
 }
@@ -138,9 +172,39 @@ MCPMessage StdioTransport::SendAndReceive(const MCPMessage &message) {
 		MCP_LOG_PROTOCOL(true, config.command_path, json);
 		WriteToProcess(json + "\n");
 
-		string response = ReadFromProcess();
-		MCP_LOG_PROTOCOL(false, config.command_path, response);
-		return MCPMessage::FromJSON(response);
+		// Read until the peer's answer to *this* request arrives.
+		//
+		// A single ReadFromProcess() returns whatever line is next on the pipe,
+		// which is not necessarily our response. MCP servers may interleave
+		// notifications (notifications/message, notifications/progress,
+		// notifications/tools/list_changed) and may send requests of their own,
+		// and a late answer to a request we already timed out on can still be
+		// sitting in the buffer. Returning any of those as "the response" is
+		// silent corruption: a notification carries a NULL result, which callers
+		// read as an empty resource/tool list or as the string "NULL", and the
+		// real response then stays buffered so every later call answers the
+		// previous question -- a permanent, well-formed, entirely wrong offset.
+		for (int skipped = 0;; skipped++) {
+			string response = ReadFromProcess();
+			MCP_LOG_PROTOCOL(false, config.command_path, response);
+			auto parsed = MCPMessage::FromJSON(response);
+
+			if (parsed.type != MCPMessageType::RESPONSE) {
+				MCP_LOG_DEBUG("TRANSPORT", "Skipping server-initiated '%s' while awaiting response to id %s",
+				              parsed.method.c_str(), DescribeId(message.id).c_str());
+			} else if (!MessageIdMatches(message.id, parsed.id)) {
+				MCP_LOG_WARN("TRANSPORT", "Discarding stale response for id %s while awaiting id %s",
+				             DescribeId(parsed.id).c_str(), DescribeId(message.id).c_str());
+			} else {
+				return parsed;
+			}
+
+			if (skipped >= MAX_UNRELATED_MESSAGES) {
+				throw IOException("No response to request id " + DescribeId(message.id) + " after " +
+				                  std::to_string(MAX_UNRELATED_MESSAGES) + " unrelated messages from " +
+				                  config.command_path);
+			}
+		}
 	} catch (const std::exception &e) {
 		MCP_LOG_ERROR("TRANSPORT", "SendAndReceive failed for %s: %s", config.command_path, e.what());
 		throw;

--- a/src/protocol/mcp_transport.cpp
+++ b/src/protocol/mcp_transport.cpp
@@ -38,6 +38,23 @@ string DescribeId(const Value &id) {
 	return id.IsNull() ? string("<null>") : id.ToString();
 }
 
+//! True for an error answer that carries no id to correlate against.
+//!
+//! JSON-RPC 2.0 section 5: "If there was an error in detecting the id in the
+//! Request object (e.g. Parse error/Invalid Request), it MUST be Null." A peer
+//! that could not parse our request has no id to echo, so id matching can never
+//! accept such an answer -- and `MCPMessage::FromJSON` renders a JSON null id as
+//! an empty VARCHAR rather than a NULL Value, so both forms have to be checked.
+//!
+//! Only one request is ever outstanding on this transport (SendAndReceive holds
+//! io_mutex for the whole round trip), so an uncorrelated error is unambiguously
+//! the answer to ours. Discarding it would replace the peer's own diagnosis with
+//! a read timeout thirty seconds later, which is exactly the kind of silent
+//! substitution the correlation loop exists to prevent.
+bool IsUncorrelatedError(const MCPMessage &msg) {
+	return msg.has_error && (msg.id.IsNull() || msg.id.ToString().empty());
+}
+
 //! How many unrelated messages to step over before giving up on a response.
 //! Notifications are unbounded in principle, so this is a liveness backstop,
 //! not a protocol limit.
@@ -192,11 +209,11 @@ MCPMessage StdioTransport::SendAndReceive(const MCPMessage &message) {
 			if (parsed.type != MCPMessageType::RESPONSE) {
 				MCP_LOG_DEBUG("TRANSPORT", "Skipping server-initiated '%s' while awaiting response to id %s",
 				              parsed.method.c_str(), DescribeId(message.id).c_str());
-			} else if (!MessageIdMatches(message.id, parsed.id)) {
+			} else if (MessageIdMatches(message.id, parsed.id) || IsUncorrelatedError(parsed)) {
+				return parsed;
+			} else {
 				MCP_LOG_WARN("TRANSPORT", "Discarding stale response for id %s while awaiting id %s",
 				             DescribeId(parsed.id).c_str(), DescribeId(message.id).c_str());
-			} else {
-				return parsed;
 			}
 
 			if (skipped >= MAX_UNRELATED_MESSAGES) {

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -832,7 +832,11 @@ static string FormatArgumentValue(const string &key, const JSONArgumentParser &p
 				if (pos != value.size()) {
 					throw std::invalid_argument("trailing characters");
 				}
-				return std::to_string(numeric_val);
+				// Re-render the *parsed* double rather than echoing the input so
+				// the injection guard above still holds -- but render it with
+				// DuckDB's shortest round-trip formatting, not std::to_string,
+				// which is "%f" and would emit 1e-7 as the literal 0.000000.
+				return Value::DOUBLE(numeric_val).ToString();
 			}
 		} catch (const std::exception &) {
 			throw InvalidInputException("Parameter '" + key + "' must be a valid " + param_type + ", got: " + value);

--- a/test/mcpfs/mock_noisy_server.sh
+++ b/test/mcpfs/mock_noisy_server.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Mock MCP server used by test/sql/mcp_client_message_routing.test.
+#
+# It is "noisy" in the way real MCP servers are: before answering any request
+# other than `initialize` it emits a `notifications/message` line. Notifications
+# are legal at any point in the stream and carry no id, so a client that simply
+# takes the next line off the pipe as "the response" gets the notification
+# instead -- and the real response then stays buffered and is served to the
+# *next* request.
+#
+# It also echoes back what it actually received for `prompts/get`, so a client
+# that drops the params on the wire is visible in the result rather than only
+# in a "Missing prompt name" error.
+
+respond() {
+    # $1 = id, $2 = result JSON
+    printf '{"jsonrpc":"2.0","id":%s,"result":%s}\n' "$1" "$2"
+}
+
+chatter() {
+    printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","logger":"mock","data":"working on it"}}'
+}
+
+INIT_RESULT='{"protocolVersion":"2024-11-05","capabilities":{"resources":{},"tools":{},"prompts":{}},"serverInfo":{"name":"noisy-mock","version":"1.0"}}'
+TOOLS_RESULT='{"tools":[{"name":"noisy_tool","description":"a tool"}]}'
+RESOURCES_RESULT='{"resources":[{"uri":"res://noisy","name":"noisy","mimeType":"text/plain"}]}'
+
+while IFS= read -r line; do
+    method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+    id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+
+    # Notifications carry no id and must not be answered.
+    if [ -z "$id" ]; then
+        continue
+    fi
+
+    case "$method" in
+    initialize)
+        # Deliberately quiet: the handshake must succeed either way, so that the
+        # test isolates the corruption to the calls that follow it.
+        respond "$id" "$INIT_RESULT"
+        ;;
+    ping)
+        respond "$id" '{}'
+        ;;
+    tools/list)
+        chatter
+        respond "$id" "$TOOLS_RESULT"
+        ;;
+    resources/list)
+        chatter
+        respond "$id" "$RESOURCES_RESULT"
+        ;;
+    prompts/get)
+        chatter
+        # Report what actually arrived. Pre-fix the client serialised
+        # `params: {}` for prompts/get, so both of these come back empty.
+        got_name=$(printf '%s' "$line" | sed -n 's/.*"name":"\([^"]*\)".*/\1/p')
+        if printf '%s' "$line" | grep -q '"table":"sales"'; then
+            got_args=yes
+        else
+            got_args=no
+        fi
+        respond "$id" "{\"description\":\"echo\",\"got_name\":\"$got_name\",\"got_args\":\"$got_args\",\"messages\":[]}"
+        ;;
+    *)
+        chatter
+        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":"Method not found"}}\n' "$id"
+        ;;
+    esac
+done

--- a/test/mcpfs/mock_noisy_server.sh
+++ b/test/mcpfs/mock_noisy_server.sh
@@ -21,6 +21,15 @@ chatter() {
     printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","logger":"mock","data":"working on it"}}'
 }
 
+# Optional mode argument. `nullid` makes the server answer every tools/list with a
+# JSON-RPC error carrying `"id": null` -- what a peer MUST send when it could not
+# determine the id of the request it is answering (JSON-RPC 2.0 section 5). It
+# keeps serving afterwards, so the answer is the same however many times the
+# caller asks; the test pairs it with a short ATTACH timeout so that a client
+# which wrongly discards the answer fails in seconds rather than after the
+# thirty-second default read timeout.
+MODE="${1:-normal}"
+
 INIT_RESULT='{"protocolVersion":"2024-11-05","capabilities":{"resources":{},"tools":{},"prompts":{}},"serverInfo":{"name":"noisy-mock","version":"1.0"}}'
 TOOLS_RESULT='{"tools":[{"name":"noisy_tool","description":"a tool"}]}'
 RESOURCES_RESULT='{"resources":[{"uri":"res://noisy","name":"noisy","mimeType":"text/plain"}]}'
@@ -45,6 +54,10 @@ while IFS= read -r line; do
         ;;
     tools/list)
         chatter
+        if [ "$MODE" = nullid ]; then
+            printf '%s\n' '{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error from mock"}}'
+            continue
+        fi
         respond "$id" "$TOOLS_RESULT"
         ;;
     resources/list)

--- a/test/mcpfs/mock_pagination_server.sh
+++ b/test/mcpfs/mock_pagination_server.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Mock MCP server used by test/sql/mcp_list_cursor.test.
+#
+# Speaks just enough JSON-RPC 2.0 over stdio to answer `initialize` and the
+# three MCP list methods, each of which is *paginated*: the first page carries
+# a `nextCursor`, and asking again with that cursor returns the second page.
+#
+# It behaves like a standards-compliant MCP server in one respect that matters
+# for the test: it exposes no tools at all, so a `tools/call` for a tool named
+# `list_resources_paginated` (or the tools/prompts equivalents) is answered
+# with a JSON-RPC error, exactly as a real server would.
+
+respond() {
+    # $1 = id, $2 = result JSON
+    printf '{"jsonrpc":"2.0","id":%s,"result":%s}\n' "$1" "$2"
+}
+
+fail() {
+    # $1 = id, $2 = code, $3 = message
+    printf '{"jsonrpc":"2.0","id":%s,"error":{"code":%s,"message":"%s"}}\n' "$1" "$2" "$3"
+}
+
+INIT_RESULT='{"protocolVersion":"2024-11-05","capabilities":{"resources":{},"tools":{},"prompts":{}},"serverInfo":{"name":"pagination-mock","version":"1.0"}}'
+
+RESOURCES_P1='{"resources":[{"uri":"res://page1","name":"page1","mimeType":"text/plain"}],"nextCursor":"CURSOR-2"}'
+RESOURCES_P2='{"resources":[{"uri":"res://page2","name":"page2","mimeType":"text/plain"}]}'
+
+TOOLS_P1='{"tools":[{"name":"tool_page1","description":"first page"}],"nextCursor":"CURSOR-2"}'
+TOOLS_P2='{"tools":[{"name":"tool_page2","description":"second page"}]}'
+
+PROMPTS_P1='{"prompts":[{"name":"prompt_page1","description":"first page"}],"nextCursor":"CURSOR-2"}'
+PROMPTS_P2='{"prompts":[{"name":"prompt_page2","description":"second page"}]}'
+
+while IFS= read -r line; do
+    method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+    id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+    cursor=$(printf '%s' "$line" | sed -n 's/.*"cursor":"\([^"]*\)".*/\1/p')
+
+    # Notifications carry no id and must not be answered.
+    if [ -z "$id" ]; then
+        continue
+    fi
+
+    case "$method" in
+    initialize)
+        respond "$id" "$INIT_RESULT"
+        ;;
+    ping)
+        respond "$id" '{}'
+        ;;
+    resources/list)
+        if [ "$cursor" = "CURSOR-2" ]; then
+            respond "$id" "$RESOURCES_P2"
+        elif [ -z "$cursor" ]; then
+            respond "$id" "$RESOURCES_P1"
+        else
+            fail "$id" -32602 "Invalid cursor"
+        fi
+        ;;
+    tools/list)
+        if [ "$cursor" = "CURSOR-2" ]; then
+            respond "$id" "$TOOLS_P2"
+        elif [ -z "$cursor" ]; then
+            respond "$id" "$TOOLS_P1"
+        else
+            fail "$id" -32602 "Invalid cursor"
+        fi
+        ;;
+    prompts/list)
+        if [ "$cursor" = "CURSOR-2" ]; then
+            respond "$id" "$PROMPTS_P2"
+        elif [ -z "$cursor" ]; then
+            respond "$id" "$PROMPTS_P1"
+        else
+            fail "$id" -32602 "Invalid cursor"
+        fi
+        ;;
+    tools/call)
+        # A real MCP server has no `list_*_paginated` tool. Reject it the way
+        # the spec says: an error, not a page of results.
+        name=$(printf '%s' "$line" | sed -n 's/.*"name":"\([^"]*\)".*/\1/p')
+        fail "$id" -32602 "Unknown tool: $name"
+        ;;
+    *)
+        fail "$id" -32601 "Method not found"
+        ;;
+    esac
+done

--- a/test/sql/mcp_argument_fidelity.test
+++ b/test/sql/mcp_argument_fidelity.test
@@ -1,0 +1,158 @@
+# name: test/sql/mcp_argument_fidelity.test
+# description: tool and prompt arguments must survive JSON -> binding without losing precision or type
+# group: [sql]
+
+# Reproduce-first regression test for two server-side argument defects.
+#
+# (1) `JSONUtils::GetValueAsString` -- the only accessor used to read tool call
+#     arguments before binding them -- rendered JSON reals with
+#     `std::to_string`, which is "%f": six digits after the decimal point.
+#     `0.0000001` became the string "0.000000", which `std::stod` then parsed
+#     cleanly as 0.0 and bound as a perfectly valid parameter. The
+#     full-string-consumed guard that protects against injection cannot see
+#     this, because the truncated text parses without trailing characters. The
+#     tool call succeeds and returns the wrong rows.
+#
+# (2) Prompt template arguments were accepted only when the JSON value was a
+#     string (`yyjson_is_str`). A client following an integer-typed argument
+#     schema sends a JSON number, which was dropped -- and `MCPTemplate::Render`
+#     substitutes an unbound *optional* variable with the empty string, so the
+#     mangled prompt came back as a successful `prompts/get`.
+#
+# Everything here runs against the in-process memory server, so no child
+# process and no network are involved.
+
+require duckdb_mcp
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+SELECT mcp_server_start('memory');
+
+# =============================================================================
+# ARG-01: a small double must not be truncated to zero
+# =============================================================================
+
+statement ok
+SELECT mcp_publish_tool(
+    'threshold_probe',
+    'Reports whether the bound threshold survived',
+    'SELECT CASE WHEN $threshold = 0.0 THEN ''TRUNCATED-TO-ZERO'' ELSE ''PRECISE'' END AS verdict',
+    '{"threshold": {"type": "number", "description": "a threshold"}}',
+    '["threshold"]'
+);
+
+# Pre-fix: "0.0000001" -> "0.000000" -> 0.0 -> TRUNCATED-TO-ZERO, reported as a
+# successful tool call.
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"threshold_probe","arguments":{"threshold":0.0000001}}}') LIKE '%PRECISE%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"threshold_probe","arguments":{"threshold":0.0000001}}}') LIKE '%TRUNCATED-TO-ZERO%';
+----
+false
+
+# A value that is already representable in six decimals must keep working.
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"threshold_probe","arguments":{"threshold":0.5}}}') LIKE '%PRECISE%';
+----
+true
+
+# Zero really is zero.
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"threshold_probe","arguments":{"threshold":0}}}') LIKE '%TRUNCATED-TO-ZERO%';
+----
+true
+
+# =============================================================================
+# ARG-02: a double must not silently lose its low digits
+# =============================================================================
+
+statement ok
+SELECT mcp_publish_tool(
+    'exact_probe',
+    'Reports whether the bound value is bit-exact',
+    'SELECT CASE WHEN $v = 1.23456789 THEN ''EXACT'' ELSE ''ROUNDED'' END AS verdict',
+    '{"v": {"type": "number", "description": "a value"}}',
+    '["v"]'
+);
+
+# Pre-fix: bound as 1.234568.
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"exact_probe","arguments":{"v":1.23456789}}}') LIKE '%EXACT%';
+----
+true
+
+# =============================================================================
+# ARG-03: integers still bind exactly
+# =============================================================================
+
+statement ok
+SELECT mcp_publish_tool(
+    'int_probe',
+    'Echoes a bound integer',
+    'SELECT $n AS n',
+    '{"n": {"type": "integer", "description": "a number"}}',
+    '["n"]'
+);
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"int_probe","arguments":{"n":9007199254740993}}}') LIKE '%9007199254740993%';
+----
+true
+
+# =============================================================================
+# ARG-04: a numeric prompt argument must render, not vanish
+# =============================================================================
+
+statement ok
+SELECT mcp_register_prompt_template('rowcount', 'Top-N prompt', 'Top {limit} rows of {table}');
+
+# Pre-fix: 'Top  rows of sales' -- `limit` was dropped for not being a JSON
+# string, and an unbound optional variable renders as the empty string.
+
+query I
+SELECT mcp_render_prompt_template('rowcount', '{"limit": 10, "table": "sales"}');
+----
+Top 10 rows of sales
+
+# Booleans too.
+
+statement ok
+SELECT mcp_register_prompt_template('flagged', 'Flag prompt', 'verbose={verbose}');
+
+query I
+SELECT mcp_render_prompt_template('flagged', '{"verbose": true}');
+----
+verbose=true
+
+# Strings keep working.
+
+query I
+SELECT mcp_render_prompt_template('rowcount', '{"limit": "all", "table": "sales"}');
+----
+Top all rows of sales
+
+# =============================================================================
+# ARG-05: the same, over the prompts/get wire path
+# =============================================================================
+# This exercises the separate copy of the argument loop that reads params
+# arriving as a JSON string rather than as a STRUCT.
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":7,"method":"prompts/get","params":{"name":"rowcount","arguments":{"limit":10,"table":"sales"}}}') LIKE '%Top 10 rows of sales%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);

--- a/test/sql/mcp_client_message_routing.test
+++ b/test/sql/mcp_client_message_routing.test
@@ -99,3 +99,30 @@ yes
 
 statement ok
 DETACH noisy;
+
+# =============================================================================
+# ROUTE-04: an error answer that carries no id is still ours
+# =============================================================================
+# JSON-RPC 2.0 section 5 requires a peer that could not determine the id of the
+# request it is answering -- a parse error, an invalid request -- to answer with
+# `"id": null`. Id correlation must not throw that away: only one request is ever
+# outstanding on this transport, so the answer is unambiguously ours. Discarding
+# it replaces the peer's own diagnosis with a read timeout, which is the same
+# class of silent substitution the correlation loop was added to prevent.
+#
+# The mock answers every tools/list this way and keeps serving, so the assertion
+# is idempotent. TIMEOUT 1 keeps the *failing* direction quick: a client that
+# discards the answer finds nothing else on the pipe and surfaces
+# "ERROR: Request failed after retries" in a few seconds rather than after the
+# thirty-second default read timeout.
+
+statement ok
+ATTACH '' AS nullid (TYPE mcp, COMMAND '/bin/sh', ARGS '["test/mcpfs/mock_noisy_server.sh","nullid"]', TRANSPORT 'stdio', TIMEOUT 1);
+
+query I
+SELECT mcp_list_tools('nullid') LIKE 'MCP_ERROR:%Parse error from mock%';
+----
+true
+
+statement ok
+DETACH nullid;

--- a/test/sql/mcp_client_message_routing.test
+++ b/test/sql/mcp_client_message_routing.test
@@ -1,0 +1,101 @@
+# name: test/sql/mcp_client_message_routing.test
+# description: a stdio client must answer from its own response, not from whatever line is next on the pipe
+# group: [sql]
+
+# Reproduce-first regression test for two client-side wire defects.
+#
+# (1) `StdioTransport::SendAndReceive` wrote the request and then returned
+#     `MCPMessage::FromJSON(ReadFromProcess())` -- the next line off the pipe,
+#     whatever it was. Nothing in the tree ever compared the response id to the
+#     request id. MCP servers legally interleave notifications
+#     (`notifications/message`, `notifications/progress`, ...), which have no id
+#     and no result, so:
+#       - the notification was returned as "the response", whose NULL result
+#         reads as an empty list or the literal string "NULL"; and
+#       - the real response stayed in `read_buffer`, so the *next* call returned
+#         the previous call's answer. A permanent, well-formed, silent offset.
+#
+# (2) `MCPMessage::ToJSON` dispatched on method name and only knew `initialize`,
+#     `resources/read` and `tools/call`. A STRUCT params value for any other
+#     method fell through to the catch-all and was replaced with `{}`.
+#     `mcp_get_prompt()` builds exactly such a STRUCT, so the prompt name and
+#     every argument were dropped on the wire.
+#
+# The fixture is a local mock MCP server (test/mcpfs/mock_noisy_server.sh)
+# spawned over stdio. It emits a notification before every non-handshake
+# response and echoes back what it received for prompts/get.
+
+require duckdb_mcp
+
+require json
+
+require notwindows
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+LOAD json;
+
+statement ok
+SET allowed_mcp_commands='/bin/sh';
+
+statement ok
+ATTACH '' AS noisy (TYPE mcp, COMMAND '/bin/sh', ARGS '["test/mcpfs/mock_noisy_server.sh"]', TRANSPORT 'stdio');
+
+# =============================================================================
+# ROUTE-01: a notification before the response must not be mistaken for it
+# =============================================================================
+# Pre-fix this is NULL: the notification is returned as the response, its result
+# is a NULL Value, and `Value::ToString()` on it yields the string "NULL".
+
+query I
+SELECT json_extract_string(mcp_list_tools('noisy'), '$.tools[0].name');
+----
+noisy_tool
+
+# =============================================================================
+# ROUTE-02: consecutive calls must not be off by one
+# =============================================================================
+# Pre-fix the tools/list response left over from ROUTE-01 is handed to this
+# resources/list call, so the resource list is NULL while the *tool* list
+# reappears under the wrong function.
+
+query I
+SELECT json_extract_string(mcp_list_resources('noisy'), '$.resources[0].uri');
+----
+res://noisy
+
+query I
+SELECT json_extract_string(mcp_list_resources('noisy'), '$.tools[0].name') IS NULL;
+----
+true
+
+# Repeat both, interleaved: every call must answer its own question.
+
+query II
+SELECT json_extract_string(mcp_list_tools('noisy'), '$.tools[0].name'),
+       json_extract_string(mcp_list_resources('noisy'), '$.resources[0].uri');
+----
+noisy_tool	res://noisy
+
+# =============================================================================
+# ROUTE-03: prompts/get params must reach the peer
+# =============================================================================
+# The mock reports back the `name` and the `arguments` it actually received.
+# Pre-fix both are empty because the client serialised `"params":{}`.
+
+query I
+SELECT json_extract_string(
+    mcp_get_prompt('noisy', 'greeting', '{"table": "sales"}'), '$.got_name');
+----
+greeting
+
+query I
+SELECT json_extract_string(
+    mcp_get_prompt('noisy', 'greeting', '{"table": "sales"}'), '$.got_args');
+----
+yes
+
+statement ok
+DETACH noisy;

--- a/test/sql/mcp_list_cursor.test
+++ b/test/sql/mcp_list_cursor.test
@@ -1,0 +1,131 @@
+# name: test/sql/mcp_list_cursor.test
+# description: the two-argument mcp_list_* functions must page with the MCP list method, not a tools/call
+# group: [sql]
+
+# Reproduce-first regression test.
+#
+# `mcp_list_resources(server, cursor)`, `mcp_list_tools(server, cursor)` and
+# `mcp_list_prompts(server, cursor)` are the cursor-aware overloads, and
+# docs/guides/client-usage.md documents them as *the* way to walk a paginated
+# server:
+#
+#     SELECT mcp_list_resources('data_server', '') as first_page;
+#     ... mcp_list_resources('data_server', json_extract_string(result, '$.nextCursor'))
+#
+# They did not send `resources/list` with a `cursor` param at all. They sent
+# `tools/call` for a tool named `list_resources_paginated` (and the tools /
+# prompts equivalents). No such tool exists in the MCP specification, so on any
+# standards-compliant server every one of these calls came back an error --
+# swallowed into a `{"error": ...}` JSON value, which `json_extract_string`
+# then reads as NULL. The user sees no page 1, no page 2, and no exception.
+#
+# The fixture is a local mock MCP server (test/mcpfs/mock_pagination_server.sh)
+# spawned over stdio: it pages all three list methods and, like a real server,
+# answers tools/call for those invented tool names with a JSON-RPC error.
+
+require duckdb_mcp
+
+require json
+
+require notwindows
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+LOAD json;
+
+statement ok
+SET allowed_mcp_commands='/bin/sh';
+
+statement ok
+ATTACH '' AS pager (TYPE mcp, COMMAND '/bin/sh', ARGS '["test/mcpfs/mock_pagination_server.sh"]', TRANSPORT 'stdio');
+
+# =============================================================================
+# resources: first page, cursor, second page
+# =============================================================================
+# Pre-fix all three of these are NULL: the result value is
+# {"error": "MCP list resources failed: Unknown tool: list_resources_paginated"}.
+
+query I
+SELECT json_extract_string(mcp_list_resources('pager', ''), '$.resources[0].uri');
+----
+res://page1
+
+query I
+SELECT json_extract_string(mcp_list_resources('pager', ''), '$.nextCursor');
+----
+CURSOR-2
+
+query I
+SELECT json_extract_string(mcp_list_resources('pager', 'CURSOR-2'), '$.resources[0].uri');
+----
+res://page2
+
+# The empty-cursor two-arg form must agree with the one-arg form.
+
+query I
+SELECT json_extract_string(mcp_list_resources('pager'), '$.resources[0].uri')
+     = json_extract_string(mcp_list_resources('pager', ''), '$.resources[0].uri');
+----
+true
+
+# A NULL cursor propagates to NULL, per ordinary DuckDB scalar semantics -- it
+# does not silently mean "first page". Pinned here because the documented paging
+# recipe below relies on it: the walk stops when `$.nextCursor` is absent, and
+# would otherwise loop back to page 1 forever.
+
+query I
+SELECT mcp_list_resources('pager', NULL) IS NULL;
+----
+true
+
+# =============================================================================
+# tools: same contract
+# =============================================================================
+
+query I
+SELECT json_extract_string(mcp_list_tools('pager', ''), '$.tools[0].name');
+----
+tool_page1
+
+query I
+SELECT json_extract_string(mcp_list_tools('pager', 'CURSOR-2'), '$.tools[0].name');
+----
+tool_page2
+
+# =============================================================================
+# prompts: same contract
+# =============================================================================
+
+query I
+SELECT json_extract_string(mcp_list_prompts('pager', ''), '$.prompts[0].name');
+----
+prompt_page1
+
+query I
+SELECT json_extract_string(mcp_list_prompts('pager', 'CURSOR-2'), '$.prompts[0].name');
+----
+prompt_page2
+
+# =============================================================================
+# The documented recursive-CTE walk reaches both pages.
+# =============================================================================
+# This is the recipe in docs/guides/client-usage.md. Pre-fix it terminates
+# immediately with a single error row.
+
+query I
+WITH RECURSIVE pages AS (
+    SELECT 1 AS page_num, mcp_list_resources('pager', '') AS result
+    UNION ALL
+    SELECT page_num + 1, mcp_list_resources('pager', json_extract_string(result, '$.nextCursor'))
+    FROM pages
+    WHERE json_extract_string(result, '$.nextCursor') IS NOT NULL
+      AND page_num < 5
+)
+SELECT string_agg(json_extract_string(result, '$.resources[0].uri'), ',' ORDER BY page_num) FROM pages;
+----
+res://page1,res://page2
+
+statement ok
+DETACH pager;


### PR DESCRIPTION
Triage of the **#67** umbrella, "Code review: correctness & usability findings (2026-07)".

## The umbrella itself

| Item | Verdict | Evidence |
|---|---|---|
| mcpfs resource-content extraction is hand-rolled string scanning | **already fixed** | `MCPFileHandle::LoadResourceContent()` on `main` parses with yyjson (`ExtractResourceContents`, `src/mcpfs/mcp_file_system.cpp:16-97`); landed in #76, merged as `f264b6b`. `test/sql/mcpfs_resource_content.test` pins the decoy-key, multi-part and blob cases. Re-ran: green. |
| Windows stdio transport unimplemented | **deferred, correctly** | Still `NotImplementedException` at `src/protocol/mcp_transport.cpp:174,443,467`, but the message now names the actual scope of the gap and points at WSL, and README + `docs/reference/client.md` say the same. It is a **loud** failure, so it is not in the band this review prioritised. Implementing it needs `CreateProcess`, named pipes with overlapped I/O, a Job Object and Windows argv quoting, none of it testable from Linux. Leaving the box unchecked. |

So — consistent with the rest of this fleet — the umbrella described nothing live. What follows is what the surrounding code turned up.

## What this PR actually fixes

Five defects, all in the band that matters most here: **a wrong answer with no error**, invisible to the peer on the other end of the pipe. Every one was reproduced before being touched.

### 1. The stdio client never matched a response to its request (worst of the five)

`StdioTransport::SendAndReceive` wrote the request and returned `MCPMessage::FromJSON(ReadFromProcess())` — the next line off the pipe, whatever it was. Nothing in the tree ever compared ids. MCP servers legally interleave notifications, which carry no id and no result.

Observed against a mock server that emits one `notifications/message` before each response:

```
SELECT mcp_list_tools('noisy');      -- NULL
SELECT mcp_list_resources('noisy');  -- {"tools":[{"name":"noisy_tool","description":"a tool"}]}
```

The notification is consumed as the response (NULL result), and the real response stays buffered and is served to the **next** call. A client that asks for resources is handed tools. The offset is permanent, every answer is well-formed, and nothing raises. The retry-after-timeout path leaves the same offset behind when a slow server eventually answers.

Now: read until the response whose id matches, stepping over notifications and stale answers, with a liveness backstop. `read_buffer` is cleared on connect and disconnect so a reconnect cannot inherit the dead process's trailing bytes.

### 2. The documented pagination recipe could not work

`mcp_list_resources(server, cursor)`, `mcp_list_tools(...)`, `mcp_list_prompts(...)` — the cursor overloads that `docs/guides/client-usage.md` documents as *the* way to page a server — never sent `resources/list` with a cursor. They sent `tools/call` for an invented tool named `list_resources_paginated`. No MCP server exposes that, so page 1 and every later page came back as a swallowed `{"error": ...}`, which `json_extract_string` reads as NULL.

Worth recording how it survived since 2025-07: `test/dev/test_pagination_scenarios.sql` calls `mcp_list_resources_paginated`, a name that is **not registered**, against `document_server`, which is **not attached** — and `docs/internal/PAGINATION_TEST_REPORT.md` records the resulting errors as *"All failure modes handle gracefully with NULL returns"* and *"zero failures"*. The report measured its own description rather than the artifact.

The error value was also being built by interpolating raw exception text into a JSON column unescaped; now escaped.

### 3. Float tool arguments truncated to six decimal places

`JSONUtils::GetValueAsString` — the only accessor used to read tool-call arguments before binding — rendered JSON reals with `std::to_string`, i.e. `"%f"`.

```
{"threshold": 0.0000001}  ->  "0.000000"  ->  std::stod  ->  bound as 0.0
```

The tool call succeeds and returns the wrong rows. The full-string-consumed guard that protects against injection cannot catch this, because the truncated text parses cleanly. `1.23456789` bound as `1.234568`. `FormatArgumentValue` applied the same truncation a second time in the substitution fallback.

### 4. `prompts/get` params dropped on the wire

`MCPMessage::ToJSON` dispatched on method name and knew only `initialize`, `resources/read` and `tools/call`; a STRUCT for anything else hit a catch-all that replaced it with `{}`. `mcp_get_prompt()` builds exactly such a STRUCT, so the prompt name and every argument were dropped. The peer answered "Missing prompt name" — which reads like a missing prompt, not a client that corrupted its own request.

### 5. Numeric prompt arguments silently vanished

Prompt template arguments were accepted only when `yyjson_is_str`. A client following an integer-typed argument schema sends a JSON number. It was dropped, and `Render()` substitutes an unbound *optional* variable with the empty string:

```
'Top {limit} rows of {table}' + {"limit": 10, "table": "sales"}  ->  'Top  rows of sales'
```

returned as a **successful** `prompts/get`. Fixed in all three copies of that loop.

## Verification

Three new test files, each confirmed **RED on the unfixed build and GREEN after** — the source fixes were stashed, rebuilt, and the failures watched, before being restored:

- `test/sql/mcp_client_message_routing.test` — notification interleaving, call-to-call desync, `prompts/get` params. Mock server `test/mcpfs/mock_noisy_server.sh`.
- `test/sql/mcp_list_cursor.test` — all three cursor overloads plus the documented recursive-CTE walk. Mock server `test/mcpfs/mock_pagination_server.sh`.
- `test/sql/mcp_argument_fidelity.test` — float precision, integer exactness, numeric/boolean prompt arguments, over both the render path and the `prompts/get` wire path. In-process memory server, no child process.

Both mock servers are local `/bin/sh` stdio servers with fixed payloads — no network. Both new stdio tests are `require notwindows`.

Suite: **1247 assertions / 39 cases** (was 1121/34), plus **56 integration tests**, all passing.

Only the files touched here were run through `clang-format`; `make format-fix` is destructive in this repo (#82) and `src/server/webmcp_transport.cpp` is untouched.

## Not touched

Nothing here overlaps #79, #80 or #81.

## Reported, not fixed

Three further findings, all real but either lower-band or larger than this PR — happy to file them separately:

1. **Queued tool registrations that fail at server start are swallowed.** `MCPServer::ApplyRegistrationsTo` (`src/server/mcp_server.cpp:962-1012`) counts failures, logs them, returns `void`, and clears `pending_tools`; `StartServer` ignores it. `mcp_publish_execution_tool` with malformed bindings JSON returns `QUEUED: ...`, `mcp_server_start` returns success, and the tool is simply gone. The non-queued path is loud, so this is a queued-path asymmetry.
2. **Markdown result formatter does not escape newlines.** `ResultFormatter::EscapeMarkdownCell` (`src/result_formatter.cpp:215-221`) escapes `|` only, so a cell containing a newline splits one row into several in the rendered table — the consumer sees a different row count than the query returned.
3. **`MCPFileSystem::Glob` returns a short or empty file list.** `MCPConnection::ListResources` never follows `nextCursor`, so only page 1 is globbed; and `Glob` wraps its whole body in `catch (...) { }` returning empty. Its pattern matching is also `StringUtil::Contains`, not glob — the existing `mcpfs_resource_content.test` already notes the swallowed-error half as known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
