### PR TITLE
fix(format): close both silent formatter corruptions (#82, #85)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,45 @@
-duckdb/.clang-format
+# Vendored copy of duckdb/.clang-format (DuckDB v1.5.x).
+#
+# This used to be a symlink into the `duckdb` submodule. That link dangles in
+# any checkout where submodules are not initialised -- a `git worktree add`, a
+# shallow CI clone, a fresh clone before `git submodule update` -- and
+# clang-format does NOT error on a missing config. It silently falls back to
+# LLVM defaults (2-space indent / 80 columns) and reformats whole files, which
+# looks exactly like a legitimate style change. See issue #85.
+#
+# Keep this in sync with duckdb/.clang-format when bumping the submodule;
+# `make format-config-check` reports drift.
+---
+BasedOnStyle: LLVM
+SortIncludes: false
+TabWidth: 4
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: false
+---
+UseTab: ForIndentation
+DerivePointerAlignment: false
+PointerAlignment: Right
+AlignConsecutiveMacros: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AlignAfterOpenBracket: Align
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes
+IncludeBlocks: Regroup
+Language: Cpp
+AccessModifierOffset: -4
+KeepEmptyLinesAtTheStartOfBlocks: false
+---
+Language: Java
+SpaceAfterCStyleCast: true
+---

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -29,6 +29,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Formatting-tooling regression tests (issues #82, #85). Deliberately cheap and
+  # deliberately FIRST: both bugs it guards are silent -- clang-format exits 0 in
+  # each case -- so nothing downstream would ever notice them.
+  #
+  # `submodules` is intentionally left at the default (not checked out). That is
+  # precisely the #85 scenario: with `.clang-format` a symlink into the duckdb
+  # submodule, the config dangles here and clang-format falls back to LLVM
+  # defaults without complaint. This job only passes because the config is now a
+  # real file in the repo.
+  format-safety:
+    name: Formatting safety (#82, #85)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      # Pinned to the version DuckDB formats with; a different major version
+      # would report drift that `make format-fix` locally would not reproduce.
+      - name: Install clang-format 11
+        run: pip install 'clang_format==11.0.1'
+      - name: Run formatting safety tests
+        run: |
+          chmod +x test/format/test_format_safety.sh
+          ./test/format/test_format_safety.sh
+
   duckdb-next-build:
     name: Canary — build against DuckDB main (advisory)
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ venv/
 !.lq/hooks/
 !.lq/config.toml
 !.lq/commands.toml
+
+# scratch dir created by test/format/test_format_safety.sh (must live inside the
+# project so clang-format finds .clang-format by parent-directory search)
+.format-safety-test.*

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,50 @@ test_all: test_all_release
 
 test_all_release: test_release integration_test_release
 	@echo "All tests completed."
+
+#===----------------------------------------------------------------------===#
+# Formatting guards (issues #82, #85)
+#===----------------------------------------------------------------------===#
+# The format targets themselves come from extension-ci-tools. They are wrapped
+# here rather than redefined: `format-check` etc. gain a prerequisite, not a new
+# recipe, so upstream stays authoritative for what formatting means.
+#
+# The hazard being guarded is that clang-format does NOT error when its config
+# is missing. It falls back to LLVM defaults and rewrites every file it touches,
+# exit 0, nothing in the log. `.clang-format` used to be a symlink into the
+# duckdb submodule, so that happened in any worktree or shallow clone (#85).
+.PHONY: format-config-check format-safety-test
+
+format-config-check:
+	@if [ ! -e "$(PROJ_DIR).clang-format" ]; then \
+		echo "ERROR: $(PROJ_DIR).clang-format does not resolve."; \
+		echo "       clang-format would NOT error here -- it would silently fall back to"; \
+		echo "       LLVM defaults and reformat every file wholesale (see issue #85)."; \
+		echo "       Refusing to run the formatter."; \
+		exit 1; \
+	fi
+	@command -v clang-format >/dev/null 2>&1 || { \
+		echo "ERROR: clang-format not found on PATH."; \
+		echo "       Install clang-format 11 (pip install 'clang_format==11.0.1')."; \
+		exit 1; \
+	}
+	@col=`cd "$(PROJ_DIR)" && clang-format --dump-config 2>/dev/null | grep -E '^ColumnLimit:' | head -1 | awk '{print $$2}'`; \
+	if [ "$$col" != "120" ]; then \
+		echo "ERROR: effective clang-format style is not DuckDB's (ColumnLimit=$$col, expected 120)."; \
+		echo "       Refusing to run the formatter -- see issue #85."; \
+		exit 1; \
+	fi
+	@if [ -f "$(PROJ_DIR)duckdb/.clang-format" ]; then \
+		if ! grep -v '^#' "$(PROJ_DIR).clang-format" | diff -q - "$(PROJ_DIR)duckdb/.clang-format" >/dev/null 2>&1; then \
+			echo "NOTE: .clang-format has drifted from duckdb/.clang-format. If the submodule"; \
+			echo "      bump was intentional, refresh the vendored copy (keeping its header)."; \
+		fi; \
+	fi
+
+# Add the guard as a prerequisite of the upstream format targets.
+format-check format format-fix format-main: format-config-check
+
+# Regression tests for the two silent-corruption modes (#82 EM_JS, #85 config).
+format-safety-test:
+	@chmod +x $(PROJ_DIR)test/format/test_format_safety.sh
+	$(PROJ_DIR)test/format/test_format_safety.sh

--- a/src/duckdb_mcp_extension.cpp
+++ b/src/duckdb_mcp_extension.cpp
@@ -756,8 +756,8 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 			// no authentication. Loopback binds (localhost/127.x/::1) remain allowed.
 			{
 				string addr = StringUtil::Lower(bind_address);
-				bool is_loopback = (addr == "localhost" || addr == "127.0.0.1" || addr == "::1" ||
-				                    addr == "[::1]" || StringUtil::StartsWith(addr, "127."));
+				bool is_loopback = (addr == "localhost" || addr == "127.0.0.1" || addr == "::1" || addr == "[::1]" ||
+				                    StringUtil::StartsWith(addr, "127."));
 				if (!is_loopback && server_config.auth_token.empty()) {
 					return CreateMCPStatus(false, false,
 					                       "Refusing to start MCP server: bind_address '" + bind_address +

--- a/src/server/tool_handlers.cpp
+++ b/src/server/tool_handlers.cpp
@@ -89,9 +89,9 @@ bool IsReadOnlyStatementType(StatementType type) {
 // those are documented residual risks.
 static bool ReferencesFileAccessFunction(const string &sql, string &matched_out) {
 	static const char *const kDeniedFns[] = {
-	    "read_text",        "read_blob",     "read_csv",        "read_csv_auto", "read_json",
-	    "read_json_auto",   "read_json_objects", "read_ndjson",  "read_ndjson_auto", "read_parquet",
-	    "parquet_scan",     "read_xlsx",     "read_arrow",      "sniff_csv",     "glob"};
+	    "read_text",      "read_blob",         "read_csv",    "read_csv_auto",    "read_json",
+	    "read_json_auto", "read_json_objects", "read_ndjson", "read_ndjson_auto", "read_parquet",
+	    "parquet_scan",   "read_xlsx",         "read_arrow",  "sniff_csv",        "glob"};
 	string lower = StringUtil::Lower(sql);
 	for (const char *fn : kDeniedFns) {
 		string needle(fn);

--- a/src/server/webmcp_transport.cpp
+++ b/src/server/webmcp_transport.cpp
@@ -33,6 +33,18 @@ void SetActiveWebMCPTransport(WebMCPTransport *transport) {
 // EM_JS functions — JS interop for navigator.modelContext
 //===--------------------------------------------------------------------===//
 
+// clang-format off
+//
+// DO NOT REMOVE THIS GUARD. The bodies below are JavaScript, not C++, but they
+// reach clang-format as ordinary macro arguments and are reformatted as C++.
+// The concrete damage is the strict-inequality operator: `!==` is not a C++
+// operator, so it is reparsed as `!=` followed by `=` and respaced to `!= =`,
+// which is a JavaScript syntax error. These bodies are compiled into the WASM
+// build only, so native builds and the native test suite cannot see the break --
+// `make format-fix` would corrupt WASM silently. See issue #82.
+//
+// test/format/test_format_safety.sh asserts this guard still holds.
+
 // Check if navigator.modelContext is available
 EM_JS(int, webmcp_check_available, (), {
 	if (typeof navigator !== 'undefined' && navigator.modelContext) {
@@ -125,6 +137,8 @@ EM_JS(const char *, webmcp_list_page_tools_js, (), {
 	}
 	return stringToNewUTF8("[]");
 });
+
+// clang-format on
 
 //===--------------------------------------------------------------------===//
 // Extern "C" callback — JS execute handler calls this

--- a/test/README.md
+++ b/test/README.md
@@ -9,3 +9,29 @@ or
 ```bash
 make test_debug
 ```
+## Formatting safety tests (`test/format/`)
+
+`test/format/test_format_safety.sh` guards two ways this repo's formatting
+tooling used to damage source *without saying so* — in both, clang-format
+exits 0:
+
+- **#82** — clang-format formats `EM_JS` macro arguments as C++, rewriting the
+  JavaScript strict-inequality operator `!==` to `!= =`. Those bodies compile
+  into the WASM build only, so native builds and native tests cannot see the
+  break.
+- **#85** — `.clang-format` used to be a symlink into the `duckdb` submodule.
+  Wherever submodules are not initialised (worktrees, shallow clones) it
+  dangled, and clang-format silently fell back to LLVM defaults, reformatting
+  whole files.
+
+```bash
+make format-safety-test          # or: ./test/format/test_format_safety.sh
+```
+
+Requires clang-format 11 (`pip install 'clang_format==11.0.1'`). It is a hard
+requirement rather than a skip: skipping when the tool is missing is the same
+silent-pass failure mode the script exists to catch. It runs in CI as the
+`format-safety` job, deliberately without submodules checked out.
+
+The `make format-*` targets additionally refuse to run when the style config
+does not resolve or is not DuckDB's — see `format-config-check` in the Makefile.

--- a/test/format/test_format_safety.sh
+++ b/test/format/test_format_safety.sh
@@ -108,9 +108,15 @@ CTRL_CODE_HITS="$(grep '!= =' "$UNGUARDED" | grep -cv '^\s*//' || true)"
 if [ "$CTRL_CODE_HITS" -gt 0 ]; then
 	pass "without the guard, clang-format produces $CTRL_CODE_HITS occurrence(s) of '!= =' (exit 0, no error)"
 else
-	warn "the '!== -> != =' corruption no longer reproduces with this clang-format."
-	echo "        Test 3 below is therefore not proving anything. Re-check issue #82"
-	echo "        before concluding the guard can be dropped."
+	# fail, not warn. If this control stops reproducing, assertion 3 below is
+	# passing vacuously -- the exact "guard has become decorative" state this
+	# control exists to detect. A warning here would be discovered by nobody:
+	# the job would stay green and the guard would silently stop meaning
+	# anything. Verified to reproduce on clang-format 11.0.1 (the pinned
+	# version) and 18.1.8, so this failing is real news, not version drift.
+	fail "the '!== -> != =' corruption no longer reproduces with this clang-format."
+	echo "        Assertion 3 below is therefore not proving anything. Re-check issue"
+	echo "        #82 and this control before concluding the guard can be dropped."
 fi
 echo
 

--- a/test/format/test_format_safety.sh
+++ b/test/format/test_format_safety.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Regression test for the two ways this repo's formatting tooling used to damage
+# source without saying so. Both share the dangerous property that *the tool
+# succeeds*: exit 0, nothing in the log, and a large plausible-looking diff.
+#
+#   #82  clang-format reformats the JavaScript inside EM_JS macros as C++.
+#        `!==` is not a C++ operator, so it is reparsed as `!=` followed by `=`
+#        and respaced to `!= =` — a JavaScript syntax error. Those bodies are
+#        compiled into the WASM build ONLY, so native builds and the native test
+#        suite cannot see the break.
+#
+#   #85  `.clang-format` used to be a symlink into the `duckdb` submodule. In a
+#        `git worktree add`, a shallow CI clone, or a fresh clone before
+#        `git submodule update`, the link dangles — and clang-format does not
+#        error on a missing config. It silently falls back to LLVM defaults
+#        (2-space / 80 col) and reformats whole files.
+#
+# This script asserts the fixes for both, plus that the tree as a whole is
+# format-clean, so that a future `make format-fix` is a no-op diff and any
+# reintroduction of the EM_JS corruption is impossible to miss in review.
+#
+# Requires clang-format (DuckDB uses 11.0.1). It is a hard requirement, not a
+# skip: silently skipping is the same failure mode the test exists to catch.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
+
+EM_JS_FILE="src/server/webmcp_transport.cpp"
+
+FAILURES=0
+WARNINGS=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+warn() { echo "  WARN: $1"; WARNINGS=$((WARNINGS + 1)); }
+
+if ! command -v "$CLANG_FORMAT" >/dev/null 2>&1; then
+	echo "ERROR: $CLANG_FORMAT not found. Install clang-format 11 (e.g. pip install 'clang_format==11.0.1')"
+	echo "       or set CLANG_FORMAT=/path/to/clang-format."
+	exit 1
+fi
+
+cd "$PROJECT_DIR" || exit 1
+
+echo "=========================================="
+echo "Formatting safety tests (#82, #85)"
+echo "=========================================="
+echo "clang-format: $("$CLANG_FORMAT" --version)"
+echo "project:      $PROJECT_DIR"
+echo
+
+# The scratch dir MUST live inside the project. clang-format finds its style by
+# walking up the parent directories of the file being formatted, so a copy in
+# /tmp would be formatted with LLVM defaults and every comparison below would be
+# measuring the wrong thing.
+TMPDIR_TEST="$(mktemp -d "$PROJECT_DIR/.format-safety-test.XXXXXX")"
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+
+#-----------------------------------------------------------------------------
+# 1. (#85) The style config must actually resolve, and must be DuckDB's style.
+#-----------------------------------------------------------------------------
+echo "[1] .clang-format resolves to a real DuckDB-style config"
+
+if [ ! -e .clang-format ]; then
+	fail ".clang-format does not resolve (missing, or a dangling symlink)."
+	echo "       clang-format would silently fall back to LLVM defaults here."
+elif [ -L .clang-format ]; then
+	# A resolving symlink is not fatal, but it is how #85 happened: the target
+	# was inside the duckdb submodule, which is absent in worktrees/shallow CI.
+	warn ".clang-format is a symlink ($(readlink .clang-format)). See issue #85 —"
+	echo "        a link into a submodule dangles in worktrees and shallow clones."
+else
+	pass ".clang-format is a regular file"
+fi
+
+# The load-bearing assertion is not "a file exists" but "DuckDB's style is in
+# effect". LLVM defaults are ColumnLimit 80 / UseTab Never; DuckDB is 120 /
+# ForIndentation. This catches a fallback no matter how it comes about.
+DUMPED="$("$CLANG_FORMAT" --dump-config 2>/dev/null)"
+COL="$(echo "$DUMPED" | grep -E '^ColumnLimit:' | head -1 | awk '{print $2}')"
+TABS="$(echo "$DUMPED" | grep -E '^UseTab:' | head -1 | awk '{print $2}')"
+if [ "$COL" = "120" ] && [ "$TABS" = "ForIndentation" ]; then
+	pass "effective style is DuckDB's (ColumnLimit=120, UseTab=ForIndentation)"
+else
+	fail "effective style is NOT DuckDB's (ColumnLimit=$COL, UseTab=$TABS)"
+	echo "       clang-format has fallen back to defaults — every file it touches"
+	echo "       will be rewritten wholesale."
+fi
+echo
+
+#-----------------------------------------------------------------------------
+# 2. (#82) Negative control: prove the corruption is real without the guard.
+#-----------------------------------------------------------------------------
+# Without this, test 3 would pass vacuously the day clang-format stops mangling
+# EM_JS — and we would not notice that the guard had become decorative.
+echo "[2] negative control: corruption reproduces when the guard is removed"
+
+UNGUARDED="$TMPDIR_TEST/unguarded.cpp"
+grep -v -e '^// clang-format off$' -e '^// clang-format on$' "$EM_JS_FILE" >"$UNGUARDED"
+"$CLANG_FORMAT" -i "$UNGUARDED"
+CTRL_HITS="$(grep -c '!= =' "$UNGUARDED" || true)"
+# The guard's own explanatory comment mentions the broken operator; drop those.
+CTRL_CODE_HITS="$(grep '!= =' "$UNGUARDED" | grep -cv '^\s*//' || true)"
+if [ "$CTRL_CODE_HITS" -gt 0 ]; then
+	pass "without the guard, clang-format produces $CTRL_CODE_HITS occurrence(s) of '!= =' (exit 0, no error)"
+else
+	warn "the '!== -> != =' corruption no longer reproduces with this clang-format."
+	echo "        Test 3 below is therefore not proving anything. Re-check issue #82"
+	echo "        before concluding the guard can be dropped."
+fi
+echo
+
+#-----------------------------------------------------------------------------
+# 3. (#82) The guard is present and the EM_JS JavaScript survives formatting.
+#-----------------------------------------------------------------------------
+echo "[3] EM_JS bodies survive clang-format unchanged"
+
+if grep -q '^// clang-format off$' "$EM_JS_FILE" && grep -q '^// clang-format on$' "$EM_JS_FILE"; then
+	pass "clang-format off/on guard present in $EM_JS_FILE"
+else
+	fail "clang-format off/on guard missing from $EM_JS_FILE"
+fi
+
+GUARDED="$TMPDIR_TEST/guarded.cpp"
+cp "$EM_JS_FILE" "$GUARDED"
+"$CLANG_FORMAT" -i "$GUARDED"
+if cmp -s "$GUARDED" "$EM_JS_FILE"; then
+	pass "clang-format is a no-op on $EM_JS_FILE"
+else
+	fail "clang-format modifies $EM_JS_FILE"
+	diff -u "$EM_JS_FILE" "$GUARDED" | head -40
+fi
+
+# Assert on the operator directly, so this still means something even if the
+# whole-file comparison above is ever relaxed.
+STRICT_BEFORE="$(grep -c '!==' "$EM_JS_FILE" || true)"
+STRICT_AFTER="$(grep -c '!==' "$GUARDED" || true)"
+BROKEN_AFTER="$(grep '!= =' "$GUARDED" | grep -cv '^\s*//' || true)"
+if [ "$STRICT_BEFORE" -eq 0 ]; then
+	warn "no '!==' left in $EM_JS_FILE — this test's subject has moved"
+elif [ "$STRICT_AFTER" -eq "$STRICT_BEFORE" ] && [ "$BROKEN_AFTER" -eq 0 ]; then
+	pass "all $STRICT_BEFORE strict-inequality operators intact, no '!= =' introduced"
+else
+	fail "strict-inequality damaged: $STRICT_BEFORE '!==' before, $STRICT_AFTER after, $BROKEN_AFTER '!= =' introduced"
+fi
+echo
+
+#-----------------------------------------------------------------------------
+# 4. (#82, follow-on) The tree is format-clean, so format-fix is a no-op diff.
+#-----------------------------------------------------------------------------
+# A large formatting diff is exactly what hides a corruption like #82. Keeping
+# the tree at zero drift is what makes the next one visible.
+echo "[4] src/ and test/ are already format-clean"
+
+DRIFTED=0
+while IFS= read -r f; do
+	FORMATTED="$TMPDIR_TEST/fmt.cpp"
+	"$CLANG_FORMAT" "$f" >"$FORMATTED" 2>/dev/null
+	if ! cmp -s "$FORMATTED" "$f"; then
+		echo "       drift: $f ($(diff "$f" "$FORMATTED" | grep -c '^[<>]') lines)"
+		DRIFTED=$((DRIFTED + 1))
+	fi
+done < <(find src test -type f \( -name '*.cpp' -o -name '*.hpp' \) | sort)
+
+if [ "$DRIFTED" -eq 0 ]; then
+	pass "no formatting drift in src/ or test/"
+else
+	fail "$DRIFTED file(s) drift from the configured style — run 'make format-fix'"
+fi
+echo
+
+echo "=========================================="
+if [ "$FAILURES" -eq 0 ]; then
+	echo "All formatting safety tests PASSED ($WARNINGS warning(s))"
+	exit 0
+fi
+echo "$FAILURES formatting safety test(s) FAILED ($WARNINGS warning(s))"
+exit 1


### PR DESCRIPTION
Fixes two formatting-tooling bugs that damage source **without saying so**, and reports back on the third issue rather than implementing it, because the evidence contradicts its premise.

Closes #82. Closes #85.

Both fixed bugs share the property that makes them dangerous: **the tool succeeds.** clang-format exits 0 in each case. No error, no non-zero exit, nothing in the log. The only tell is the size of the diff — and a large diff is exactly what a formatter is expected to produce.

---

## #82 — `make format-fix` corrupts `EM_JS` JavaScript

clang-format formats `EM_JS` macro arguments as C++. `!==` is not a C++ operator, so it is reparsed as `!=` followed by `=` and respaced to `!= =`, a JavaScript syntax error. Those bodies compile into the **WASM build only**, so native builds and the native test suite cannot see the break.

**Before** (clang-format 11.0.1, DuckDB's own `.clang-format`):

```
$ clang-format -i src/server/webmcp_transport.cpp ; echo "exit=$?"
exit=0
$ grep -c '!= =' src/server/webmcp_transport.cpp
3
```

**After:**

```
$ clang-format src/server/webmcp_transport.cpp | diff - src/server/webmcp_transport.cpp
$ echo "exit=$?"
exit=0        # no-op
```

This is not hypothetical damage — the JavaScript is embedded verbatim in the distributed artifact. From the last green run on `main`:

```
$ gh run download 34195974120 --pattern '*wasm_eh*'
$ strings duckdb_mcp.duckdb_extension.wasm | grep -c 'read_only !== 0'
1
```

**Fix:** `// clang-format off` / `on` around the `EM_JS` block — the smallest of the three options in the issue. **Purely additive; comment lines only, no code touched.**

**Plus the pre-existing drift**, settled in its own commit so a future `format-fix` is a clean no-op and the next corruption is signal rather than noise. Only two files drifted (`src/duckdb_mcp_extension.cpp`, `src/server/tool_handlers.cpp`), both whitespace-only — token streams verified identical:

```
$ git show HEAD~1:src/duckdb_mcp_extension.cpp | tr -d '[:space:]' | md5sum
95c5d7e24c862aefd24c1fd28cc5bf54
$ tr -d '[:space:]' < src/duckdb_mcp_extension.cpp | md5sum
95c5d7e24c862aefd24c1fd28cc5bf54
```

---

## #85 — `.clang-format` symlink dangles in worktrees and shallow clones

Reproduced in a fresh `git worktree add` off `origin/main`:

```
$ ls -la .clang-format
lrwxrwxrwx  .clang-format -> duckdb/.clang-format
$ test -e .clang-format && echo RESOLVES || echo DANGLING
DANGLING
$ clang-format -i src/protocol/mcp_transport.cpp ; echo "exit=$?"
exit=0
# 1025 lines silently rewritten to LLVM defaults
```

**Fix — both options from the issue, because option 2 alone would not have caught the reported incident:**

1. **`.clang-format` is now a real file** — a verbatim copy of `duckdb/.clang-format` with an explanatory header. `clang-format --dump-config` is byte-identical between the two, so **nothing about the resulting style changes**. This is what protects a *bare* `clang-format` invocation, which is how #85 was actually hit during review of #83; a Makefile guard alone would not have.
2. **`make format-check` / `format` / `format-fix` / `format-main` gain a `format-config-check` prerequisite** that refuses to run when the config does not resolve, when clang-format is absent, or when the effective style is not DuckDB's. The upstream recipes from `extension-ci-tools` are untouched — only a prerequisite is added — so upstream stays authoritative for what formatting means. It also emits a non-fatal NOTE when the vendored copy drifts from the submodule's, so a style-changing submodule bump is visible.

Guard verified on all paths (against a stub `extension-ci-tools` include, exit code checked, never grepped output):

| condition | result |
|---|---|
| config resolves | `STUB: format-fix ran`, exit 0 |
| config dangles | `ERROR: ... does not resolve`, **exit 2, format-fix never ran** |
| clang-format absent | `ERROR: clang-format not found on PATH`, exit 2 |
| vendored copy drifts | non-fatal `NOTE:`, format-check still runs |

---

## Automated coverage

`test/format/test_format_safety.sh` + a new `format-safety` CI job. **Both fixes are covered by an automated check**, not just a documented procedure.

Four assertions:

1. **(#85)** `.clang-format` resolves **and DuckDB's style is actually in effect** (`ColumnLimit=120`, `UseTab=ForIndentation`). The second is the load-bearing one — it catches a fallback however it arises, not just the symlink case.
2. **(#82) A negative control.** With the `clang-format off/on` lines stripped, clang-format must *still* produce `!= =`. Without this, assertion 3 would pass vacuously the day clang-format changes behaviour and the guard would quietly become decorative.
3. **(#82)** The guard is present, clang-format is a no-op on the file, and every `!==` survives with no `!= =` introduced.
4. `src/` and `test/` are format-clean.

**Red/green — same script, only the tree differs:**

```
pre-fix tree (symlinked config, no EM_JS guard):  6 FAIL, exit 1
post-fix tree:                                    0 FAIL, exit 0
```

Two details worth noting:

- The CI job **deliberately does not check out submodules**. That is precisely the #85 scenario: with the old symlink the config dangles there and clang-format reformats everything without complaint. The job passes only because the config is now a real file.
- clang-format is a **hard requirement** of the script, not a skip. Silently skipping when the tool is missing is the same failure mode the script exists to catch.

---

## #66 — WASM exclusion: NOT applied, premise is stale

**I did not make this change, and I recommend #66 be closed rather than implemented.** Its premise no longer matches the tree.

#66 says the extension "fundamentally needs sockets / stdio" and should be excluded from the wasm matrix, listing as future/out-of-scope work: *"(a) drop stdio transport from the wasm build via `#ifdef EMSCRIPTEN` guards."*

**That work already landed** — in `c11eb17` (2026-02-24), *four months before #66 was filed.* `CMakeLists.txt` explicitly partitions the sources:

```cmake
# Sources that are incompatible with WASM (process management, HTTP server, ...)
if(NOT EMSCRIPTEN)
  list(APPEND EXTENSION_SOURCES src/protocol/mcp_transport.cpp
       src/server/stdio_server_transport.cpp ...)
endif()

# WASM-only sources (WebMCP browser integration)
if(EMSCRIPTEN)
  list(APPEND EXTENSION_SOURCES src/server/webmcp_transport.cpp)
endif()
```

**The matrix is green.** All three wasm archs succeed on both legs of the last run on `main` (34195974120):

```
success  Build extension binaries / DuckDB-Wasm (wasm_eh, ...)
success  Build extension binaries / DuckDB-Wasm (wasm_mvp, ...)
success  Build extension binaries / DuckDB-Wasm (wasm_threads, ...)
```

**And the artifact carries a real feature** — measured, not assumed:

```
$ strings duckdb_mcp.duckdb_extension.wasm | grep -o 'MCP server started on WebMCP transport.*'
MCP server started on WebMCP transport (browser navigator.modelContext)
$ node -e '...WebAssembly.Module.imports...'
total imports: 890   by module: { env: 504, 'GOT.mem': 230, 'GOT.func': 156 }
socket/exec imports: 0     # all `env` imports are duckdb C++ symbols
```

No POSIX socket, `fork`, or `exec` imports. The extension gates itself at runtime: *"Only 'memory' and 'webmcp' transports are available in WASM."*

Excluding wasm now would delete three green build targets and drop a shipped browser feature. That is a product regression, not CI hygiene. What #66 was really pointing at — *"compiling isn't running"* — is still open, but the honest fix is the **opposite** of exclusion: port the sibling extensions' `test/wasm/` load check (static symbol gate + informational live load in duckdb-wasm) so we actually verify the artifact loads. That is a separate, larger change and is not in this PR.

---

## Notes

- Nothing here touches `src/mcp_server.cpp`, `src/mcpfs/`, or `src/result_formatter.cpp` (issue #84's files).
- One thing to be aware of: assertion 4 makes format-cleanliness a **hard CI gate** for the first time in this repo. Any in-flight branch that lands unformatted code will now go red. The remedy is `make format-fix`, which — after this PR — is finally safe to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
