### PR TITLE
Fix three silent failures from #84: swallowed registrations, fake glob, markdown cells

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,47 @@ All notable changes to the DuckDB MCP Extension.
 
 ### Fixed
 
+- **A failed registration no longer reports a successful server start** (#84).
+  `ApplyRegistrationsTo()` returned `void`, `StartServer()` ignored what happened
+  inside it, and the pending queue was cleared either way. A queued tool or
+  resource that threw when it was applied — malformed `properties_json`, for
+  instance, which is only parsed at that point — was logged and then forgotten:
+  `mcp_server_start()` reported success, the server came up, and the tool simply
+  was not there. The operator saw a clean startup, the client saw a missing tool,
+  and nothing anywhere said it had failed to register.
+
+  Registrations are now built before any of them is applied, so the outcome is
+  all-or-nothing. If any of them cannot be built, none are registered, the queue
+  is left intact, the server is stopped again and the status struct comes back
+  with `success`/`running` false and a message naming each failure. Publishing a
+  name that is already queued now replaces that entry rather than appending a
+  duplicate, matching what happens against a running server and giving a way to
+  correct a bad queued registration. An unknown pending resource type, previously
+  skipped in silence, is reported like any other failure.
+
+- **`mcp://` globs are globs, span every page, and raise on error** (#84).
+  `MCPFileSystem::Glob()` called `resources/list` once and never followed
+  `nextCursor`, so only the first page of a paginated server was ever considered;
+  it matched with `StringUtil::Contains()` rather than glob semantics, so `*.csv`
+  matched nothing at all while a wildcard-free pattern naming no resource could
+  match plenty; and the whole body sat inside `catch (...) {}`, so a missing
+  attachment, a dead transport or a JSON-RPC error came back as an empty match
+  list. Three ways to get a short or wrong file list, none of which raised.
+
+  Matching now uses DuckDB's glob semantics over every page of `resources/list`,
+  a wildcard-free pattern names exactly one resource, and errors propagate.
+  `MCPConnection` gained `ListResourcesPage()` and `ListAllResources()`; the
+  existing `ListResources()` still returns a single page.
+
+- **Markdown cells can no longer add rows or columns** (#84).
+  `EscapeMarkdownCell()` escaped only `|`. A cell holding a newline split one
+  result row into several rendered table rows, and a backslash immediately before
+  a pipe produced `\\|` — an escaped backslash followed by a live pipe — which
+  split the row into extra cells. Anything parsing the markdown back, which is
+  the point of formatting it, saw rows and columns that were never in the result
+  set, and row counts changed silently. Backslashes are now escaped, and CR, LF
+  and CRLF become a single `<br>` inside the cell.
+
 - **stdio transport: stdout now carries nothing but JSON-RPC** (#74). JSON-RPC over
   stdio requires file descriptor 1 to hold framed protocol messages and nothing else,
   but several writers reach it without going through the transport. The DuckDB CLI

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -162,6 +162,24 @@ SELECT * FROM read_parquet('mcp://server_name/file:///data/table.parquet');
 SELECT * FROM read_json('mcp://server_name/file:///api/response.json');
 ```
 
+#### Glob patterns
+
+A pattern containing `*`, `?` or `[...]` is matched against the resource URIs
+the server advertises via `resources/list`, following `nextCursor` so that every
+page is searched. Matching uses DuckDB's own glob semantics — `*` spans any run
+of characters including `/`, and brace alternation (`{a,b}`) is **not**
+supported.
+
+```sql
+-- Every CSV resource on the server, across all pages of resources/list
+SELECT * FROM glob('mcp://server_name/data://*.csv');
+```
+
+A pattern with no wildcard names exactly one resource: it matches that resource
+or nothing. It is not a substring search. Failures reaching the server — no such
+attachment, a dead transport, a JSON-RPC error — are raised rather than reported
+as an empty match list.
+
 ---
 
 ## Tool Functions

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -56,6 +56,18 @@ PRAGMA mcp_server_start('http', 'localhost', 8080, '{"auth_token": "secret"}');
 SELECT mcp_server_start('memory');
 ```
 
+!!! warning "Queued registrations are applied all-or-nothing"
+    Tools and resources published before the server starts are queued, and every
+    queued registration is applied when it does. If any of them cannot be applied
+    — malformed `properties_json` for a tool, say, which is only parsed at this
+    point — none of them are: the server is stopped again, the queue is left
+    intact, and the status struct comes back with `success` and `running` false
+    and a `message` naming each registration that failed and why.
+
+    A start that reports success therefore holds every capability that was asked
+    for. Correct the offending `mcp_publish_*` call — re-publishing a name
+    replaces the queued entry — and start again.
+
 ---
 
 ### mcp_server_stop

--- a/src/duckdb_mcp_extension.cpp
+++ b/src/duckdb_mcp_extension.cpp
@@ -512,6 +512,17 @@ static Value CreateMCPStatus(bool success, bool running, const string &message, 
 	return Value::STRUCT(values);
 }
 
+// Message for a StartServer() that returned false. A queued tool or resource
+// that could not be applied is named here rather than logged and forgotten --
+// otherwise the caller sees a start that simply did not happen, with no reason.
+static string StartFailureMessage(const vector<RegistrationFailure> &failures) {
+	string detail = DescribeRegistrationFailures(failures);
+	if (detail.empty()) {
+		return "Failed to start MCP server";
+	}
+	return "MCP server not started: " + detail;
+}
+
 // Core implementation for starting MCP server - returns MCPStatus struct
 static Value MCPServerStartCore(ClientContext &context, const string &transport, const string &bind_address, int port,
                                 const string &config_json) {
@@ -695,21 +706,27 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 			// Memory transport is always background mode (for testing with mcp_server_send_request)
 			// The server doesn't do I/O - it just waits for requests via ProcessRequest()
 			server_config.background = true;
-			if (server_manager.StartServer(server_config)) {
+			vector<RegistrationFailure> reg_failures;
+			if (server_manager.StartServer(server_config, &reg_failures)) {
 				return CreateMCPStatus(true, true, "MCP server started on memory transport (background mode)",
 				                       transport, bind_address, port, true);
 			} else {
-				return CreateMCPStatus(false, false, "Failed to start MCP server", transport, bind_address, port, true);
+				return CreateMCPStatus(false, false, StartFailureMessage(reg_failures), transport, bind_address, port,
+				                       true);
 			}
 		}
 #ifdef __EMSCRIPTEN__
 		else if (transport == "webmcp") {
 			// WebMCP transport: register tools with navigator.modelContext (WASM only)
 			server_config.background = true;
-			if (server_manager.StartServer(server_config)) {
+			vector<RegistrationFailure> reg_failures;
+			if (server_manager.StartServer(server_config, &reg_failures)) {
 				return CreateMCPStatus(true, true,
 				                       "MCP server started on WebMCP transport (browser navigator.modelContext)",
 				                       transport, bind_address, port, true);
+			} else if (!reg_failures.empty()) {
+				return CreateMCPStatus(false, false, StartFailureMessage(reg_failures), transport, bind_address, port,
+				                       true);
 			} else {
 				return CreateMCPStatus(false, false,
 				                       "Failed to start MCP server on WebMCP transport. "
@@ -722,12 +739,13 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 		else if (transport == "stdio") {
 			if (server_config.background) {
 				// Background mode: use server manager (non-blocking, starts thread)
-				if (server_manager.StartServer(server_config)) {
+				vector<RegistrationFailure> reg_failures;
+				if (server_manager.StartServer(server_config, &reg_failures)) {
 					return CreateMCPStatus(true, true, "MCP server started on stdio (background mode)", transport,
 					                       bind_address, port, true);
 				} else {
-					return CreateMCPStatus(false, false, "Failed to start MCP server", transport, bind_address, port,
-					                       true);
+					return CreateMCPStatus(false, false, StartFailureMessage(reg_failures), transport, bind_address,
+					                       port, true);
 				}
 			} else {
 				// Foreground mode (default): handle connection directly without background thread
@@ -737,7 +755,12 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 					                       port, false);
 				}
 				// Apply any pending tool/resource registrations from server_manager
-				server_manager.ApplyPendingRegistrationsTo(&server);
+				vector<RegistrationFailure> reg_failures;
+				if (!server_manager.ApplyPendingRegistrationsTo(&server, &reg_failures)) {
+					server.Stop();
+					return CreateMCPStatus(false, false, StartFailureMessage(reg_failures), transport, bind_address,
+					                       port, false);
+				}
 				try {
 					server.RunMainLoop(); // Blocks until max_requests or shutdown
 					return CreateMCPStatus(true, false, "MCP server completed", transport, bind_address, port, false,
@@ -769,12 +792,13 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 			// HTTP/HTTPS transport
 			if (server_config.background) {
 				// Background mode: use server manager (non-blocking, starts thread)
-				if (server_manager.StartServer(server_config)) {
+				vector<RegistrationFailure> reg_failures;
+				if (server_manager.StartServer(server_config, &reg_failures)) {
 					return CreateMCPStatus(true, true, "MCP server started on " + transport + " (background mode)",
 					                       transport, bind_address, port, true);
 				} else {
-					return CreateMCPStatus(false, false, "Failed to start MCP server", transport, bind_address, port,
-					                       true);
+					return CreateMCPStatus(false, false, StartFailureMessage(reg_failures), transport, bind_address,
+					                       port, true);
 				}
 			} else {
 				// Foreground mode: handle HTTP in calling thread (blocking)
@@ -784,7 +808,12 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 					                       port, false);
 				}
 				// Apply any pending tool/resource registrations from server_manager
-				server_manager.ApplyPendingRegistrationsTo(&server);
+				vector<RegistrationFailure> reg_failures;
+				if (!server_manager.ApplyPendingRegistrationsTo(&server, &reg_failures)) {
+					server.Stop();
+					return CreateMCPStatus(false, false, StartFailureMessage(reg_failures), transport, bind_address,
+					                       port, false);
+				}
 				try {
 					server.RunHTTPLoop(); // Blocks until Stop() is called or server shuts down
 					return CreateMCPStatus(true, false, "MCP server completed", transport, bind_address, port, false,
@@ -805,11 +834,13 @@ static Value MCPServerStartCore(ClientContext &context, const string &transport,
 			                       transport, bind_address, port, false);
 #else
 			// For other transports (TCP/WebSocket), use background thread
-			if (server_manager.StartServer(server_config)) {
+			vector<RegistrationFailure> reg_failures;
+			if (server_manager.StartServer(server_config, &reg_failures)) {
 				return CreateMCPStatus(true, true, "MCP server started on " + transport, transport, bind_address, port,
 				                       true);
 			} else {
-				return CreateMCPStatus(false, false, "Failed to start MCP server", transport, bind_address, port, true);
+				return CreateMCPStatus(false, false, StartFailureMessage(reg_failures), transport, bind_address, port,
+				                       true);
 			}
 #endif
 		}

--- a/src/include/protocol/mcp_connection.hpp
+++ b/src/include/protocol/mcp_connection.hpp
@@ -56,7 +56,14 @@ public:
 	}
 
 	// Resource operations
+	//
+	// ListResources() returns a single page and discards the server's
+	// `nextCursor`. A caller that must see every resource has to use
+	// ListAllResources(), or ListResourcesPage() and follow the cursor itself --
+	// otherwise a paginated server looks like it holds only its first page.
 	vector<MCPResource> ListResources(const string &cursor = "");
+	vector<MCPResource> ListResourcesPage(const string &cursor, string &next_cursor);
+	vector<MCPResource> ListAllResources(idx_t max_pages = 1000);
 	MCPResource ReadResource(const string &uri);
 	bool ResourceExists(const string &uri);
 

--- a/src/include/server/mcp_server.hpp
+++ b/src/include/server/mcp_server.hpp
@@ -279,13 +279,31 @@ struct ResourceMetadataEntry {
 	string status; // "pending" or "active"
 };
 
+// One queued registration that could not be applied when the server started.
+struct RegistrationFailure {
+	string kind; // "tool" or "resource"
+	string name; // tool name or resource URI
+	string error;
+};
+
+// Rendered as a single human-readable sentence for mcp_server_start()'s status
+// message. Empty input yields an empty string.
+string DescribeRegistrationFailures(const vector<RegistrationFailure> &failures);
+
 // Per-instance server management
 class MCPServerManager {
 public:
 	MCPServerManager() = default;
 	~MCPServerManager();
 
-	bool StartServer(const MCPServerConfig &config);
+	// Starts the server and applies every queued tool/resource registration.
+	//
+	// Registrations are validated before any of them is applied, so the outcome
+	// is all-or-nothing: if any queued registration cannot be applied, nothing
+	// is registered, the queue is left intact, the server is stopped again, the
+	// failures are reported through `out_failures` and this returns false. A
+	// registration failure is never swallowed into a successful start.
+	bool StartServer(const MCPServerConfig &config, vector<RegistrationFailure> *out_failures = nullptr);
 	void StopServer();
 	bool IsServerRunning() const;
 
@@ -315,8 +333,10 @@ public:
 	size_t GetPendingToolCount() const;
 	size_t GetPendingResourceCount() const;
 
-	// Apply pending registrations to an external server (for foreground mode)
-	void ApplyPendingRegistrationsTo(MCPServer *external_server);
+	// Apply pending registrations to an external server (for foreground mode).
+	// Same all-or-nothing contract as StartServer(); returns false and leaves
+	// the queue intact if any registration could not be applied.
+	bool ApplyPendingRegistrationsTo(MCPServer *external_server, vector<RegistrationFailure> *out_failures = nullptr);
 
 	// State introspection snapshots (for table functions)
 	vector<ToolMetadataEntry> GetToolSnapshot() const;
@@ -333,9 +353,11 @@ private:
 	vector<PendingResourceRegistration> pending_resources;
 
 	// Apply pending registrations to server
-	void ApplyPendingRegistrations();
-	// Shared implementation: apply and clear pending registrations to a target server
-	void ApplyRegistrationsTo(MCPServer *target);
+	bool ApplyPendingRegistrations(vector<RegistrationFailure> *out_failures);
+	// Shared implementation: validate every pending registration, then apply and
+	// clear them only if all of them can be built. Returns false (leaving the
+	// queue untouched) as soon as any of them cannot.
+	bool ApplyRegistrationsTo(MCPServer *target, vector<RegistrationFailure> *out_failures);
 };
 
 } // namespace duckdb

--- a/src/mcpfs/mcp_file_system.cpp
+++ b/src/mcpfs/mcp_file_system.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/open_file_info.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/blob.hpp"
+#include "duckdb/function/scalar/string_common.hpp"
 #include "json_utils.hpp"
 
 namespace duckdb {
@@ -293,39 +294,43 @@ bool MCPFileSystem::ListFiles(const string &directory, const std::function<void(
 }
 
 vector<OpenFileInfo> MCPFileSystem::Glob(const string &path, FileOpener *opener) {
+	// Errors are deliberately NOT swallowed here. This used to be wrapped in
+	// `catch (...) {}`, which turned a missing server, a dead transport or a
+	// JSON-RPC error into an empty match list -- indistinguishable from "the
+	// server holds no matching resources".
 	vector<OpenFileInfo> results;
 
-	try {
-		auto parsed_path = ValidateAndParsePath(path);
-		auto connection = GetConnection(parsed_path.server_name);
+	auto parsed_path = ValidateAndParsePath(path);
+	auto connection = GetConnection(parsed_path.server_name);
 
-		if (!connection || !connection->IsInitialized()) {
-			return results;
-		}
+	if (!connection->IsInitialized()) {
+		throw IOException("MCP connection for server '" + parsed_path.server_name + "' is not initialized");
+	}
 
-		// For exact path matching, first check if the specific resource exists
+	// A pattern with no wildcard names one resource. Ask for it directly rather
+	// than listing every resource on the server.
+	if (!FileSystem::HasGlob(parsed_path.resource_uri)) {
 		if (connection->ResourceExists(parsed_path.resource_uri)) {
-			OpenFileInfo info(path); // Use the original path as requested
-			results.push_back(info);
-		} else {
-			// List all resources and filter by pattern
-			auto resources = connection->ListResources();
-
-			for (const auto &resource : resources) {
-				string full_path = MCPPathParser::ConstructPath(parsed_path.server_name, resource.uri);
-
-				// Simple pattern matching - would implement proper glob matching
-				if (StringUtil::Contains(resource.uri, parsed_path.resource_uri) ||
-				    StringUtil::Contains(full_path, path)) {
-					OpenFileInfo info(full_path);
-					// Note: OpenFileInfo doesn't have a size field
-					// Size information would need to be stored in extended_info if needed
-					results.push_back(info);
-				}
-			}
+			results.emplace_back(path); // Use the original path as requested
 		}
-	} catch (...) {
-		// Return empty results on error
+		return results;
+	}
+
+	// Otherwise walk EVERY page of resources/list -- a server that paginates
+	// would otherwise only ever be matched against its first page -- and match
+	// with real glob semantics. Substring matching was both too loose (`*.csv`
+	// matching `a.csv.bak`) and too tight (`*.csv` matching nothing at all,
+	// since no URI contains the literal asterisk).
+	auto resources = connection->ListAllResources();
+
+	for (const auto &resource : resources) {
+		if (!duckdb::Glob(resource.uri.c_str(), resource.uri.size(), parsed_path.resource_uri.c_str(),
+		                  parsed_path.resource_uri.size())) {
+			continue;
+		}
+		results.emplace_back(MCPPathParser::ConstructPath(parsed_path.server_name, resource.uri));
+		// Note: OpenFileInfo doesn't have a size field
+		// Size information would need to be stored in extended_info if needed
 	}
 
 	return results;

--- a/src/protocol/mcp_connection.cpp
+++ b/src/protocol/mcp_connection.cpp
@@ -6,6 +6,7 @@
 #include <ctime>
 #include <thread>
 #include <chrono>
+#include <iterator>
 
 namespace duckdb {
 
@@ -105,9 +106,16 @@ bool MCPConnection::Initialize() {
 }
 
 vector<MCPResource> MCPConnection::ListResources(const string &cursor) {
+	string next_cursor;
+	return ListResourcesPage(cursor, next_cursor);
+}
+
+vector<MCPResource> MCPConnection::ListResourcesPage(const string &cursor, string &next_cursor) {
 	if (!IsInitialized()) {
 		throw InvalidInputException("Connection not initialized");
 	}
+
+	next_cursor.clear();
 
 	Value params;
 	if (!cursor.empty()) {
@@ -146,9 +154,32 @@ vector<MCPResource> MCPConnection::ListResources(const string &cursor) {
 		} else {
 			MCP_LOG_WARN("CONNECTION", "ListResources response missing 'resources' array");
 		}
+
+		if (yyjson_is_obj(root)) {
+			next_cursor = JSONUtils::GetString(root, "nextCursor");
+		}
 	}
 
 	return resources;
+}
+
+vector<MCPResource> MCPConnection::ListAllResources(idx_t max_pages) {
+	vector<MCPResource> all;
+	string cursor;
+	for (idx_t page = 0; page < max_pages; page++) {
+		string next_cursor;
+		auto page_resources = ListResourcesPage(cursor, next_cursor);
+		all.insert(all.end(), std::make_move_iterator(page_resources.begin()),
+		           std::make_move_iterator(page_resources.end()));
+		if (next_cursor.empty() || next_cursor == cursor) {
+			// No further page, or a server that keeps handing back the same
+			// cursor. Stop rather than loop forever.
+			return all;
+		}
+		cursor = std::move(next_cursor);
+	}
+	throw IOException("MCP server '" + server_name + "' returned more than " + std::to_string(max_pages) +
+	                  " pages of resources; refusing to keep paging");
 }
 
 MCPResource MCPConnection::ReadResource(const string &uri) {

--- a/src/result_formatter.cpp
+++ b/src/result_formatter.cpp
@@ -213,9 +213,40 @@ string ResultFormatter::FormatAsCSV(QueryResult &result) {
 }
 
 string ResultFormatter::EscapeMarkdownCell(const string &input) {
-	string result = input;
-	for (size_t pos = 0; (pos = result.find('|', pos)) != string::npos; pos += 2) {
-		result.replace(pos, 1, "\\|");
+	// A cell must never introduce a row or column boundary. Three characters can:
+	//   '\n' / '\r' end the table row, so one result row renders as several and
+	//               anything parsing the markdown back sees rows that were never
+	//               in the result set;
+	//   '|'         ends the cell;
+	//   '\\'        is markdown's escape character, so an unescaped backslash
+	//               immediately before a pipe turns our "\|" into an escaped
+	//               backslash followed by a *live* pipe.
+	// Line breaks become <br>, the standard way to carry a break inside a cell.
+	string result;
+	result.reserve(input.size());
+	for (size_t i = 0; i < input.size(); i++) {
+		char c = input[i];
+		switch (c) {
+		case '\\':
+			result += "\\\\";
+			break;
+		case '|':
+			result += "\\|";
+			break;
+		case '\r':
+			// Collapse CRLF into a single break rather than emitting two.
+			if (i + 1 < input.size() && input[i + 1] == '\n') {
+				i++;
+			}
+			result += "<br>";
+			break;
+		case '\n':
+			result += "<br>";
+			break;
+		default:
+			result += c;
+			break;
+		}
 	}
 	return result;
 }

--- a/src/server/mcp_server.cpp
+++ b/src/server/mcp_server.cpp
@@ -844,7 +844,7 @@ MCPServerManager::~MCPServerManager() {
 	StopServer();
 }
 
-bool MCPServerManager::StartServer(const MCPServerConfig &config) {
+bool MCPServerManager::StartServer(const MCPServerConfig &config, vector<RegistrationFailure> *out_failures) {
 	lock_guard<mutex> lock(manager_mutex);
 
 	if (server && server->IsRunning()) {
@@ -855,8 +855,14 @@ bool MCPServerManager::StartServer(const MCPServerConfig &config) {
 	bool started = server->Start();
 
 	if (started) {
-		// Apply any pending registrations
-		ApplyPendingRegistrations();
+		// Apply any pending registrations. If any of them cannot be applied the
+		// start fails: a server that is missing capabilities the operator asked
+		// for must not be reported as a clean startup.
+		if (!ApplyPendingRegistrations(out_failures)) {
+			server->Stop();
+			server.reset();
+			return false;
+		}
 	}
 
 	return started;
@@ -925,11 +931,27 @@ MCPServerManager::ServerStats MCPServerManager::GetServerStats() const {
 
 void MCPServerManager::QueueToolRegistration(PendingToolRegistration registration) {
 	lock_guard<mutex> lock(manager_mutex);
+	// Re-publishing a name replaces the queued entry, matching what happens when
+	// the server is running (ToolRegistry keys tools by name). It also means a
+	// queued registration that turns out to be unapplyable can be corrected.
+	for (auto &existing : pending_tools) {
+		if (existing.name == registration.name) {
+			existing = std::move(registration);
+			return;
+		}
+	}
 	pending_tools.push_back(std::move(registration));
 }
 
 void MCPServerManager::QueueResourceRegistration(PendingResourceRegistration registration) {
 	lock_guard<mutex> lock(manager_mutex);
+	// Same replace-by-key rule as tools; ResourceRegistry keys resources by URI.
+	for (auto &existing : pending_resources) {
+		if (existing.uri == registration.uri) {
+			existing = std::move(registration);
+			return;
+		}
+	}
 	pending_resources.push_back(std::move(registration));
 }
 
@@ -943,25 +965,48 @@ size_t MCPServerManager::GetPendingResourceCount() const {
 	return pending_resources.size();
 }
 
-void MCPServerManager::ApplyPendingRegistrations() {
+string DescribeRegistrationFailures(const vector<RegistrationFailure> &failures) {
+	if (failures.empty()) {
+		return "";
+	}
+	string msg = std::to_string(failures.size()) + " queued registration(s) could not be applied: ";
+	for (idx_t i = 0; i < failures.size(); i++) {
+		if (i > 0) {
+			msg += "; ";
+		}
+		msg += failures[i].kind + " '" + failures[i].name + "': " + failures[i].error;
+	}
+	return msg;
+}
+
+bool MCPServerManager::ApplyPendingRegistrations(vector<RegistrationFailure> *out_failures) {
 	// Note: This is called from StartServer which already holds the lock
 	if (!server) {
-		return;
+		return true;
 	}
-	ApplyRegistrationsTo(server.get());
+	return ApplyRegistrationsTo(server.get(), out_failures);
 }
 
-void MCPServerManager::ApplyPendingRegistrationsTo(MCPServer *external_server) {
+bool MCPServerManager::ApplyPendingRegistrationsTo(MCPServer *external_server,
+                                                   vector<RegistrationFailure> *out_failures) {
 	lock_guard<mutex> lock(manager_mutex);
 	if (!external_server) {
-		return;
+		return true;
 	}
-	ApplyRegistrationsTo(external_server);
+	return ApplyRegistrationsTo(external_server, out_failures);
 }
 
-void MCPServerManager::ApplyRegistrationsTo(MCPServer *target) {
-	// Apply pending tool registrations
-	idx_t tool_failures = 0;
+bool MCPServerManager::ApplyRegistrationsTo(MCPServer *target, vector<RegistrationFailure> *out_failures) {
+	// Two phases. Everything that can throw -- schema parsing, handler and
+	// provider construction -- happens first, into local vectors. Only if every
+	// queued registration builds do we touch the target's registries and clear
+	// the queue. A failure therefore leaves the server exactly as it was and the
+	// queue intact, so the caller can report it and the operator can correct the
+	// offending publish and try again.
+	vector<RegistrationFailure> failures;
+
+	vector<std::pair<string, shared_ptr<ToolHandler>>> built_tools;
+	built_tools.reserve(pending_tools.size());
 	for (auto &reg : pending_tools) {
 		try {
 			ToolInputSchema input_schema = ParseToolInputSchema(reg.properties_json, reg.required_json);
@@ -974,43 +1019,55 @@ void MCPServerManager::ApplyRegistrationsTo(MCPServer *target) {
 				handler = make_shared_ptr<SQLToolHandler>(reg.name, reg.description, reg.sql_template, input_schema,
 				                                          *reg.db_instance, reg.format);
 			}
-			target->RegisterTool(reg.name, std::move(handler));
+			built_tools.emplace_back(reg.name, std::move(handler));
 		} catch (const std::exception &e) {
-			tool_failures++;
+			failures.push_back(RegistrationFailure {"tool", reg.name, string(e.what())});
 			MCP_LOG_ERROR("SERVER", "Failed to register pending tool '%s': %s", reg.name.c_str(), e.what());
 		}
 	}
-	if (tool_failures > 0) {
-		MCP_LOG_WARN("SERVER", "%" PRIu64 " of %" PRIu64 " pending tool registration(s) failed", tool_failures,
-		             static_cast<uint64_t>(pending_tools.size()));
-	}
-	pending_tools.clear();
 
-	// Apply pending resource registrations
-	idx_t resource_failures = 0;
+	vector<std::pair<string, shared_ptr<ResourceProvider>>> built_resources;
+	built_resources.reserve(pending_resources.size());
 	for (auto &reg : pending_resources) {
 		try {
+			shared_ptr<ResourceProvider> provider;
 			if (reg.type == "table") {
-				auto provider = make_shared_ptr<TableResourceProvider>(reg.source, reg.format, *reg.db_instance);
-				target->PublishResource(reg.uri, std::move(provider));
+				provider = make_shared_ptr<TableResourceProvider>(reg.source, reg.format, *reg.db_instance);
 			} else if (reg.type == "query") {
-				auto provider = make_shared_ptr<QueryResourceProvider>(reg.source, reg.format, *reg.db_instance,
-				                                                       reg.refresh_seconds);
-				target->PublishResource(reg.uri, std::move(provider));
+				provider = make_shared_ptr<QueryResourceProvider>(reg.source, reg.format, *reg.db_instance,
+				                                                  reg.refresh_seconds);
 			} else if (reg.type == "resource") {
-				auto provider = make_shared_ptr<StaticResourceProvider>(reg.source, reg.mime_type, reg.description);
-				target->PublishResource(reg.uri, std::move(provider));
+				provider = make_shared_ptr<StaticResourceProvider>(reg.source, reg.mime_type, reg.description);
+			} else {
+				// Previously skipped in silence, which published nothing and said
+				// nothing. An unknown type is a failure like any other.
+				throw InvalidInputException("Unknown pending resource type '" + reg.type + "'");
 			}
+			built_resources.emplace_back(reg.uri, std::move(provider));
 		} catch (const std::exception &e) {
-			resource_failures++;
+			failures.push_back(RegistrationFailure {"resource", reg.uri, string(e.what())});
 			MCP_LOG_ERROR("SERVER", "Failed to register pending resource '%s': %s", reg.uri.c_str(), e.what());
 		}
 	}
-	if (resource_failures > 0) {
-		MCP_LOG_WARN("SERVER", "%" PRIu64 " of %" PRIu64 " pending resource registration(s) failed", resource_failures,
-		             static_cast<uint64_t>(pending_resources.size()));
+
+	if (!failures.empty()) {
+		MCP_LOG_WARN("SERVER", "%" PRIu64 " queued registration(s) could not be applied; none were applied",
+		             static_cast<uint64_t>(failures.size()));
+		if (out_failures) {
+			*out_failures = std::move(failures);
+		}
+		return false;
 	}
+
+	for (auto &entry : built_tools) {
+		target->RegisterTool(entry.first, std::move(entry.second));
+	}
+	for (auto &entry : built_resources) {
+		target->PublishResource(entry.first, std::move(entry.second));
+	}
+	pending_tools.clear();
 	pending_resources.clear();
+	return true;
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/mcpfs/mock_glob_server.sh
+++ b/test/mcpfs/mock_glob_server.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# Mock MCP server used by test/sql/mcpfs_glob_semantics.test (issue #84, item 3).
+#
+# Speaks just enough JSON-RPC 2.0 over stdio to answer `initialize`,
+# `resources/list` and `resources/read`.
+#
+# Two properties matter for the test:
+#
+#   1. `resources/list` is PAGINATED. The first page carries a `nextCursor`;
+#      the second page is only reachable by asking again with that cursor.
+#      `data://beta.csv` lives on page 2 and is invisible to any caller that
+#      stops after the first page.
+#
+#   2. The resource URIs are chosen so that glob matching and substring
+#      matching disagree:
+#
+#        data://alpha.csv       matches  data://*.csv    (glob and substring)
+#        data://alpha.csv.bak   matches  data://*.csv    ONLY as a substring
+#        data://notes.txt       matches  neither
+#        data://beta.csv        matches  data://*.csv    (page 2 only)
+#
+#      and the literal, wildcard-free pattern `data://alpha` names no resource
+#      at all, yet is a substring of two of them.
+
+respond() {
+    # $1 = id, $2 = result JSON
+    printf '{"jsonrpc":"2.0","id":%s,"result":%s}\n' "$1" "$2"
+}
+
+fail() {
+    # $1 = id, $2 = code, $3 = message
+    printf '{"jsonrpc":"2.0","id":%s,"error":{"code":%s,"message":"%s"}}\n' "$1" "$2" "$3"
+}
+
+INIT_RESULT='{"protocolVersion":"2024-11-05","capabilities":{"resources":{}},"serverInfo":{"name":"glob-mock","version":"1.0"}}'
+
+LIST_P1='{"resources":[{"uri":"data://alpha.csv","name":"alpha","mimeType":"text/csv"},{"uri":"data://alpha.csv.bak","name":"alpha-backup","mimeType":"text/plain"},{"uri":"data://notes.txt","name":"notes","mimeType":"text/plain"}],"nextCursor":"GLOB-PAGE-2"}'
+LIST_P2='{"resources":[{"uri":"data://beta.csv","name":"beta","mimeType":"text/csv"}]}'
+
+read_result() {
+    case "$1" in
+    "data://alpha.csv")
+        printf '%s' '{"contents":[{"uri":"data://alpha.csv","mimeType":"text/csv","text":"ALPHA"}]}'
+        ;;
+    "data://alpha.csv.bak")
+        printf '%s' '{"contents":[{"uri":"data://alpha.csv.bak","mimeType":"text/plain","text":"ALPHA-BAK"}]}'
+        ;;
+    "data://notes.txt")
+        printf '%s' '{"contents":[{"uri":"data://notes.txt","mimeType":"text/plain","text":"NOTES"}]}'
+        ;;
+    "data://beta.csv")
+        printf '%s' '{"contents":[{"uri":"data://beta.csv","mimeType":"text/csv","text":"BETA"}]}'
+        ;;
+    *)
+        printf '%s' ''
+        ;;
+    esac
+}
+
+while IFS= read -r line; do
+    method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+    id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+    cursor=$(printf '%s' "$line" | sed -n 's/.*"cursor":"\([^"]*\)".*/\1/p')
+
+    # Notifications carry no id and must not be answered.
+    if [ -z "$id" ]; then
+        continue
+    fi
+
+    case "$method" in
+    initialize)
+        respond "$id" "$INIT_RESULT"
+        ;;
+    ping)
+        respond "$id" '{}'
+        ;;
+    resources/list)
+        if [ "$cursor" = "GLOB-PAGE-2" ]; then
+            respond "$id" "$LIST_P2"
+        elif [ -z "$cursor" ]; then
+            respond "$id" "$LIST_P1"
+        else
+            fail "$id" -32602 "Invalid cursor"
+        fi
+        ;;
+    resources/read)
+        uri=$(printf '%s' "$line" | sed -n 's/.*"uri":"\([^"]*\)".*/\1/p')
+        result=$(read_result "$uri")
+        if [ -z "$result" ]; then
+            fail "$id" -32002 "Resource not found: $uri"
+        else
+            respond "$id" "$result"
+        fi
+        ;;
+    *)
+        fail "$id" -32601 "Method not found"
+        ;;
+    esac
+done

--- a/test/sql/mcp_markdown_cell_row_integrity.test
+++ b/test/sql/mcp_markdown_cell_row_integrity.test
@@ -1,0 +1,116 @@
+# name: test/sql/mcp_markdown_cell_row_integrity.test
+# description: a markdown cell must never introduce a row or column boundary (issue #84 item 2)
+# group: [sql]
+
+# Reproduce-first regression test for issue #84 (item 2).
+#
+# ResultFormatter::EscapeMarkdownCell() escaped only `|`. A cell containing a
+# newline therefore split one result row into several rendered table rows, and
+# a cell containing a backslash immediately before a pipe produced `\\|` --
+# an escaped backslash followed by a live pipe, which splits the row into two
+# cells. Anything parsing the markdown back (which is the point of formatting
+# it) saw rows and columns that were never in the result set. Row counts
+# changed silently.
+#
+# The assertions below count structure rather than eyeball the rendering. In
+# the JSON-RPC response every markdown newline is the two-character sequence
+# backslash-n, so counting those counts rendered table lines.
+
+require duckdb_mcp
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+SELECT mcp_server_start('memory');
+
+# =============================================================================
+# CORE 1: a newline inside a cell does not add a table row
+# =============================================================================
+# One row, one column. A well-formed table is exactly three lines: header,
+# alignment separator, and the single data row.
+#
+# Pre-fix the cell's newline is emitted verbatim, so the rendering has FOUR
+# lines and a markdown reader counts two data rows where the result set had one.
+
+query I
+SELECT CAST((length(r) - length(replace(r, chr(92) || 'n', ''))) / 2 AS BIGINT) FROM (
+  SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT ''a'' || chr(10) || ''b'' AS val","format":"markdown"}}}') AS r
+);
+----
+3
+
+# The line break is preserved as a cell-local break rather than dropped.
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT ''a'' || chr(10) || ''b'' AS val","format":"markdown"}}}')
+  LIKE '%a<br>b%';
+----
+true
+
+# Carriage returns and CRLF pairs collapse the same way -- one break, one row.
+
+query I
+SELECT CAST((length(r) - length(replace(r, chr(92) || 'n', ''))) / 2 AS BIGINT) FROM (
+  SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT ''a'' || chr(13) || chr(10) || ''b'' AS val","format":"markdown"}}}') AS r
+);
+----
+3
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT ''a'' || chr(13) || chr(10) || ''b'' AS val","format":"markdown"}}}')
+  LIKE '%a<br>b%';
+----
+true
+
+# A newline in a COLUMN NAME must not break the header row either. The newline
+# is written as a JSON \n escape so the request itself stays valid JSON; the
+# JSON parser turns it back into a real newline inside the quoted identifier.
+
+query I
+SELECT CAST((length(r) - length(replace(r, chr(92) || 'n', ''))) / 2 AS BIGINT) FROM (
+  SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT 1 AS \"one' || chr(92) || 'ntwo\"","format":"markdown"}}}') AS r
+);
+----
+3
+
+# Multi-row results still render one line per row.
+
+query I
+SELECT CAST((length(r) - length(replace(r, chr(92) || 'n', ''))) / 2 AS BIGINT) FROM (
+  SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT * FROM (VALUES (''x'' || chr(10) || ''y''), (''z'')) t(val)","format":"markdown"}}}') AS r
+);
+----
+4
+
+# =============================================================================
+# CORE 2: a backslash before a pipe does not add a table column
+# =============================================================================
+# Cell content is the four characters  a \ | b .
+#
+# Pre-fix only the pipe was escaped, giving the markdown  a\\|b : the reader
+# sees an escaped backslash and then a LIVE pipe, so the one-column row becomes
+# two columns.
+#
+# Post-fix the backslash is escaped too, giving  a\\\|b  -- six backslashes in
+# the JSON-RPC response, where each markdown backslash is doubled again.
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT ''a'' || chr(92) || chr(124) || ''b'' AS val","format":"markdown"}}}')
+  LIKE '%a' || repeat(chr(92), 6) || chr(124) || 'b%';
+----
+true
+
+# A bare pipe is still escaped exactly once (pinning the pre-existing #55 fix).
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"query","arguments":{"sql":"SELECT ''a'' || chr(124) || ''b'' AS val","format":"markdown"}}}')
+  LIKE '%a' || repeat(chr(92), 2) || chr(124) || 'b%';
+----
+true
+
+statement ok
+SELECT mcp_server_stop(true);

--- a/test/sql/mcp_registration_failure_reporting.test
+++ b/test/sql/mcp_registration_failure_reporting.test
@@ -1,0 +1,145 @@
+# name: test/sql/mcp_registration_failure_reporting.test
+# description: a queued registration that fails at server start must be reported, not swallowed
+# group: [sql]
+
+# Reproduce-first regression test for issue #84 (item 1).
+#
+# MCPServerManager::ApplyRegistrationsTo() returned void, StartServer() ignored
+# whatever happened inside it, and pending_tools/pending_resources were cleared
+# regardless. A queued registration that threw at start was written to the log
+# and then forgotten: mcp_server_start() reported success, the server came up,
+# and the tool simply was not there. The operator saw a clean startup; the
+# client saw a missing tool; nothing anywhere said it had failed to register.
+#
+# A tool queued while the server is stopped is NOT schema-checked at publish
+# time -- ParseToolInputSchema() runs at apply time, inside ApplyRegistrationsTo.
+# So malformed properties JSON is accepted as QUEUED and blows up at start.
+# That is the reproduction.
+
+require duckdb_mcp
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+CREATE TABLE IF NOT EXISTS reg_items AS SELECT 1 AS id, 'Widget' AS name;
+
+# =============================================================================
+# SETUP: one sound registration and one that cannot be applied
+# =============================================================================
+
+statement ok
+PRAGMA mcp_publish_tool('sound_tool', 'Lists items', 'SELECT * FROM reg_items', '{}', '[]');
+
+# Malformed properties JSON. Accepted while the server is stopped, because the
+# schema is only parsed when the registration is applied.
+statement ok
+PRAGMA mcp_publish_tool('broken_tool', 'Broken schema', 'SELECT * FROM reg_items', '{not valid json', '[]');
+
+query I
+SELECT count(*) FROM mcp_tools() WHERE status = 'pending';
+----
+2
+
+# =============================================================================
+# CORE 1: the start must NOT report success
+# =============================================================================
+# Pre-fix all three of these are the opposite: success true, running true, and
+# a message that says the server started on the memory transport.
+
+# The status struct is materialised once: `(mcp_server_start(...)).field`
+# evaluates the scalar twice, and the second call reports "already running".
+
+statement ok
+CREATE OR REPLACE TABLE start_attempt AS SELECT mcp_server_start('memory') AS s;
+
+query I
+SELECT (s).success FROM start_attempt;
+----
+false
+
+query I
+SELECT (s).running FROM start_attempt;
+----
+false
+
+# CORE 2: the message must name the registration that failed.
+
+query I
+SELECT (s).message LIKE '%broken_tool%' FROM start_attempt;
+----
+true
+
+# =============================================================================
+# CORE 3: nothing is half-applied and nothing is silently discarded
+# =============================================================================
+# Registrations are validated before any of them is applied, so a failure
+# leaves the server down and the queue intact -- rather than a running server
+# holding some of what was asked for and no record of the rest.
+
+query I
+SELECT count(*) FROM mcp_tools() WHERE status = 'pending';
+----
+2
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}') LIKE '%No MCP server running%';
+----
+true
+
+# =============================================================================
+# CORE 4: correcting the registration makes the start succeed
+# =============================================================================
+# Re-publishing a queued name replaces the queued entry, exactly as
+# re-publishing against a running server replaces the live one. Without that
+# there would be no way back from a bad queued registration.
+
+statement ok
+PRAGMA mcp_publish_tool('broken_tool', 'Fixed schema', 'SELECT * FROM reg_items', '{"id":{"type":"integer"}}', '[]');
+
+query I
+SELECT count(*) FROM mcp_tools() WHERE status = 'pending';
+----
+2
+
+statement ok
+CREATE OR REPLACE TABLE start_retry AS SELECT mcp_server_start('memory') AS s;
+
+query I
+SELECT (s).success FROM start_retry;
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}') LIKE '%sound_tool%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}') LIKE '%broken_tool%';
+----
+true
+
+query I
+SELECT mcp_server_send_request('{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"sound_tool","arguments":{}}}') LIKE '%Widget%';
+----
+true
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+
+statement ok
+SELECT mcp_server_stop(true);
+
+statement ok
+DROP TABLE IF EXISTS reg_items;
+
+statement ok
+DROP TABLE IF EXISTS start_attempt;
+
+statement ok
+DROP TABLE IF EXISTS start_retry;

--- a/test/sql/mcpfs_glob_semantics.test
+++ b/test/sql/mcpfs_glob_semantics.test
@@ -1,0 +1,105 @@
+# name: test/sql/mcpfs_glob_semantics.test
+# description: MCPFileSystem::Glob must page, match globs (not substrings), and raise instead of returning empty
+# group: [sql]
+
+# Reproduce-first regression test for issue #84 (item 3).
+#
+# MCPFileSystem::Glob() had three independent ways to hand back a short or
+# wrong file list, none of which raised:
+#
+#   1. It called MCPConnection::ListResources() once and never followed
+#      `nextCursor`, so only the first page of a paginated server was ever
+#      considered.
+#   2. It matched with StringUtil::Contains(), not glob semantics. `*.csv`
+#      therefore did not mean what a caller expects, and a wildcard-free
+#      pattern naming nothing could still match plenty.
+#   3. The whole body was wrapped in `catch (...) {}`, so a missing server, a
+#      dead transport or a JSON-RPC error all became an empty match list.
+#
+# The fixture is a local mock MCP server (test/mcpfs/mock_glob_server.sh)
+# spawned over stdio. It touches no network. Its resource set spans two pages
+# and is shaped so glob and substring matching disagree:
+#
+#   page 1: data://alpha.csv  data://alpha.csv.bak  data://notes.txt
+#   page 2: data://beta.csv
+
+require duckdb_mcp
+
+require notwindows
+
+statement ok
+LOAD duckdb_mcp;
+
+statement ok
+SET allowed_mcp_commands='/bin/sh';
+
+statement ok
+ATTACH '' AS globber (TYPE mcp, COMMAND '/bin/sh', ARGS '["test/mcpfs/mock_glob_server.sh"]', TRANSPORT 'stdio');
+
+# =============================================================================
+# CORE 1: `*.csv` means glob, and every page is searched.
+# =============================================================================
+# Pre-fix: StringUtil::Contains(uri, "data://*.csv") is false for every
+# resource, and Contains(full_path, path) likewise, so this returned ZERO rows.
+#
+# Post-fix: proper glob matching selects alpha.csv and beta.csv; it must NOT
+# select alpha.csv.bak (a substring match would) and must NOT miss beta.csv
+# (which only exists on page 2, behind `nextCursor`).
+
+query I
+SELECT string_agg(file, ',' ORDER BY file) FROM glob('mcp://globber/data://*.csv');
+----
+mcp://globber/data://alpha.csv,mcp://globber/data://beta.csv
+
+# The page-2 resource on its own, to name the pagination failure directly.
+
+query I
+SELECT count(*) FROM glob('mcp://globber/data://beta*');
+----
+1
+
+# =============================================================================
+# CORE 2: a wildcard-free pattern is a name, not a substring.
+# =============================================================================
+# `data://alpha` is not a resource on this server. Pre-fix
+# StringUtil::Contains() matched it against data://alpha.csv AND
+# data://alpha.csv.bak, so a pattern that should match nothing matched plenty.
+
+query I
+SELECT count(*) FROM glob('mcp://globber/data://alpha');
+----
+0
+
+# The exact URI still resolves, so the ordinary read path is unaffected.
+
+query I
+SELECT count(*) FROM glob('mcp://globber/data://alpha.csv');
+----
+1
+
+query I
+SELECT content FROM read_text('mcp://globber/data://alpha.csv');
+----
+ALPHA
+
+# A glob that reaches page 2 must be readable end to end, not just listable.
+
+query I
+SELECT string_agg(content, ',' ORDER BY content) FROM read_text('mcp://globber/data://*.csv');
+----
+ALPHA,BETA
+
+# =============================================================================
+# CORE 3: errors underneath must raise, not become an empty match list.
+# =============================================================================
+# There is no server attached under the name `nosuchserver`, so resolving the
+# connection throws. Pre-fix `catch (...) {}` turned that into zero matches and
+# the caller saw "no files" instead of "no such server".
+
+statement error
+SELECT count(*) FROM glob('mcp://nosuchserver/data://*.csv');
+----
+No MCP connection found in registry for server
+
+statement ok
+DETACH globber;


### PR DESCRIPTION
Closes #84.

All three defects share the shape the issue named: **a failure that looks like a result.** Each was reproduced first — a test that fails against the unmodified build and passes against the fixed one — before anything was changed.

The issue was written from a code read. All three reproduced as described; none was already fixed or mis-described.

---

## 1. Failed registrations were reported as a successful server start

`ApplyRegistrationsTo()` returned `void`, `StartServer()` ignored what happened inside it, and `pending_tools`/`pending_resources` were cleared either way.

The reproduction: a tool queued while the server is stopped is **not** schema-checked at publish time — `ParseToolInputSchema()` runs at apply time, inside `ApplyRegistrationsTo`. So malformed `properties_json` is accepted as `QUEUED` and throws at start. Measured against the pre-fix binary, the three columns of the failure read exactly:

| `mcp_server_start().success` | `broken_tool` in `tools/list` | pending registrations left |
|---|---|---|
| `true` | `false` | `0` |

A clean startup, the tool gone, the queue cleared, nothing raised.

**Fix.** Everything that can throw — schema parsing, handler and provider construction — now happens into local vectors *before* the target's registries are touched. The outcome is all-or-nothing: if any queued registration cannot be built, none are registered, the queue is left intact, the server is stopped again, and the status struct returns `success`/`running` false with a message naming each failure.

Two supporting changes:
- Publishing a name that is already queued **replaces** that entry rather than appending a duplicate. This matches what already happens against a running server (`ToolRegistry` keys by name, `ResourceRegistry` by URI), and it is what makes the fail-closed behaviour recoverable — without it a bad queued registration would wedge every subsequent start.
- An unknown pending resource type was previously skipped in silence, publishing nothing and saying nothing. It is now a failure like any other.

## 2. `MCPFileSystem::Glob` was not glob, and swallowed everything

Three independent ways to get a short or wrong file list, each reproduced separately against the pre-fix binary using a paginated mock server (`test/mcpfs/mock_glob_server.sh`):

| pattern | pre-fix | post-fix |
|---|---|---|
| `data://*.csv` | 0 matches — no URI contains a literal `*` | `alpha.csv`, `beta.csv` (not `alpha.csv.bak`) |
| `data://beta*` (page 2 only) | 0 — `nextCursor` never followed | 1 |
| `data://alpha` (names no resource) | 2 — substring match | 0 |
| `mcp://nosuchserver/data://*.csv` | 0 rows, no error | raises |

**Fix.** Matching uses DuckDB's own glob semantics (`duckdb::Glob`, gated on `FileSystem::HasGlob`) across every page of `resources/list`; a wildcard-free pattern names exactly one resource rather than being a substring search; and `catch (...) {}` is gone, so a missing attachment, a dead transport or a JSON-RPC error is raised.

`MCPConnection` gained `ListResourcesPage()` (one page plus `nextCursor`) and `ListAllResources()` (every page, bounded, and stops on a server that keeps returning the same cursor). The existing `ListResources()` is unchanged for its callers.

## 3. `EscapeMarkdownCell` escaped only `|`

A one-row, one-column result whose cell contains a newline rendered as **four** table lines instead of three — a markdown reader counts two data rows where the result set had one. Separately, a backslash immediately before a pipe produced `\\|`: an escaped backslash followed by a *live* pipe, splitting the row into extra cells.

**Fix.** Backslashes are escaped, and CR / LF / CRLF collapse to a single `<br>` inside the cell. The assertions count structure (rendered table lines, escape depth) rather than eyeballing the rendering.

---

## Verification

**Red and green used different binaries.** The red run used `unittest` sha256 `0d61235a5f4c…`, extension `02f92ce846dc…`; the green run `ce910bc3a41e…` / `35c0c78aac8c…`. To rule out a stale-binary pass, the source fixes were stashed, the tree rebuilt, and the *final* test files re-run against it: the rebuild reproduced the red hashes byte-identically and all three tests failed again, at the same assertions. Every build and test invocation was gated on `$?`, never on grepping output.

Each defect's later assertions — the ones the runner never reaches because it stops at the first failure — were additionally isolated into single-assertion probes and confirmed red individually before being folded back in. Those probes were temporary and are not part of this change.

| suite | result |
|---|---|
| `test/sql/*` | 1308 assertions / 42 cases, all passing (baseline 1250 / 39; +3 files) |
| integration | 56 passed, 0 failed |
| HTTP transport | 27 passed, 0 failed |
| HTTP foreground | 4 passed, 0 failed — exercises the `ApplyPendingRegistrationsTo` foreground path |

`make format-fix` was **not** run (it is destructive here — #82). Only the seven touched files were passed to `clang-format`, after confirming the `.clang-format` symlink resolves into the submodule rather than dangling (#85). It reformatted one pre-existing block unrelated to this change, which was reverted; everything else was already conformant.

WASM was not built locally, but CI's `wasm_mvp`, `wasm_eh` and `wasm_threads` jobs all pass. The `__EMSCRIPTEN__` branch of `mcp_server_start` was updated for the new signature; `RegistrationFailure` and `DescribeRegistrationFailures` live outside every `#ifndef __EMSCRIPTEN__` guard, and `webmcp_transport.cpp` was not touched — `make format-fix` was not run, so #82's `!==` corruption was not reintroduced.

## Behaviour change worth calling out

`mcp_server_start()` now **fails** when a queued registration cannot be applied, where it previously came up missing that capability and said nothing. Documented under `mcp_server_start` in `docs/reference/server.md`, alongside the glob semantics in `docs/reference/client.md` — the MCPFS spec advertised brace alternation (`{a,b}`), which is not supported by DuckDB's glob and is not claimed by the new note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz

